### PR TITLE
fix [always]CalledWithMatch when used with expect

### DIFF
--- a/lib/referee-sinon.js
+++ b/lib/referee-sinon.js
@@ -215,7 +215,7 @@
             "arguments ${1}${2}",
         refuteMessage: "Expected ${0} not to be called with matching " +
             "arguments${1}${2}",
-        expectation: "toHaveAlwaysBeenCalledWithExactly",
+        expectation: "toHaveBeenCalledWithMatch",
         values: spyAndCalls
     });
 
@@ -228,7 +228,7 @@
             "arguments ${1}${2}",
         refuteMessage: "Expected ${0} not to always be called with matching " +
             "arguments${1}${2}",
-        expectation: "toHaveAlwaysBeenCalledWithExactly",
+        expectation: "toHaveAlwaysBeenCalledWithMatch",
         values: spyAndCalls
     });
 


### PR DESCRIPTION
those two were not working when using expect() syntax because the expectation
name was duplicated.
