### PR TITLE
Verify all sinon assertions mapped to referee

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -16,7 +16,7 @@ rules:
   ie11/no-loop-func: warn
   ie11/no-weak-collections: error
 
-  max-len: [error, {code: 120, ignoreStrings: true}]
+  max-len: [error, {code: 120, ignoreComments: true, ignoreStrings: true}]
 
 overrides:
     files: '*.test.*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
   - node_modules
 
 before_install:
-  - npm install coveralls
+  - if [ "x$TRAVIS_NODE_VERSION" = "x8" ]; then npm install coveralls; fi
 
 before_script:
   # Make npm run work for the script phase:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,26 @@
 
 Sinon.JS assertions for the referee assertion library.
 
+## Usage
+
+```shell
+npm install referee-sinon --save-dev
+```
+
+```js
+const referee = require("referee");
+const sinon = require("sinon");
+
+// add the assertions to referee
+require("referee-sinon")(referee, sinon);
+```
+
+## Documentation
+
+https://sinonjs.github.io/referee-sinon/
+
+
+
 ## Backers
 
 Support us with a monthly donation and help us continue our activities. [[Become a backer](https://opencollective.com/sinon#backer)]

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,582 @@
+# referee-sinon
+
+Sinon.JS assertions for the referee assertion library.
+
+## Assertions
+
+The descriptions are for `assert`, but the corresponding failure messages for `refute` are also mentioned. For refute the behaviour is exactly opposite.
+
+*Overview:*
+
+* [`called()`](#called)
+* [`callOrder()`](#callorder)
+* [`calledOnce()`](#calledonce)
+* [`calledTwice()`](#calledtwice)
+* [`calledThrice()`](#calledthrice)
+* [`calledOn()`](#calledon)
+* [`alwaysCalledOn()`](#alwayscalledon)
+* [`calledWith()`](#calledwith)
+* [`alwaysCalledWith()`](alwayscalledwith)
+* [`calledOnceWith()`](#calledoncewith)
+* [`calledWithExactly()`](#calledwithexactly)
+* [`alwaysCalledWithExactly()`](#alwayscalledwithexactly)
+* [`threw()`](#threw)
+* [`alwaysThrew()`](#alwaysthrew)
+
+### `called()`
+
+```js
+assert.called(spy)
+```
+
+Fails if the `spy` has never been called.
+
+```js
+var spy = this.spy();
+
+assert.called(spy); // Fails
+
+spy();
+assert.called(spy); // Passes
+
+spy();
+assert.called(spy); // Passes
+```
+
+#### Messages
+
+```js
+assert.called.message = "Expected ${0} to be called at least once but was never called";
+```
+
+<dl>
+    <dt>`${0}`:</dt>
+    <dd>The spy</dd>
+</dl>
+
+```js
+refute.called.message = "Expected ${0} to not be called but was called ${1}${2}";
+```
+
+
+<dl>
+    <dt>`${0}`:</dt>
+    <dd>The spy</dd>
+    <dt>`${1}`:</dt>
+    <dd>The number of calls as a string. Ex: “two times”</dd>
+    <dt>`${2}`:</dt>
+    <dd>All calls formatted as a multi-line string</dd>
+</dl>
+
+### `callOrder()`
+
+```js
+assert.callOrder(spy, spy2, ...)
+```
+
+Fails if the spies were not called in the specified order.
+
+```js
+var spy1 = this.spy();
+var spy2 = this.spy();
+var spy3 = this.spy();
+
+spy1();
+spy2();
+spy3();
+
+assert.callOrder(spy1, spy3, spy2); // Fails
+assert.callOrder(spy1, spy2, spy3); // Passes
+```
+
+#### Messages
+
+```js
+assert.callOrder.message = "Expected ${expected} to be called in order but were called as ${actual}";
+refute.callOrder.message = "Expected ${expected} not to be called in order";
+```
+
+<dl>
+    <dt>`${expected}`:</dt>
+    <dd>A string representation of the expected call order</dd>
+    <dt>`${actual}`:</dt>
+    <dd>A string representation of the actual call order</dd>
+</dl>
+
+
+### `calledOnce()`
+
+```js
+assert.calledOnce(spy)
+```
+
+Fails if the `spy` has never been called or if it was called more than once.
+
+```js
+var spy = this.spy();
+
+assert.calledOnce(spy); // Fails
+
+spy();
+assert.calledOnce(spy); // Passes
+
+spy();
+assert.calledOnce(spy); // Fails
+```
+
+#### Messages
+
+```
+assert.calledOnce.message = "Expected ${0} to be called once but was called ${1}${2}";
+refute.calledOnce.message = "Expected ${0} to not be called exactly once${2}";
+```
+
+<dl>
+    <dt>`${0}`:</dt>
+    <dd>The spy</dd>
+    <dt>`${1}`:</dt>
+    <dd>The number of calls, as a string. Ex: “two times”</dd>
+    <dt>`${2}`:</dt>
+    <dd>The call log. All calls as a string. Each line is one call and includes passed arguments, returned value and more</dd>
+</dl>
+
+### `calledTwice()`
+
+```js
+assert.calledTwice(spy)
+```
+
+Only passes if the `spy` was called exactly twice.
+
+```js
+var spy = this.spy();
+
+assert.calledTwice(spy); // Fails
+
+spy();
+assert.calledTwice(spy); // Fails
+
+spy();
+assert.calledTwice(spy); // Passes
+
+spy();
+assert.calledTwice(spy); // Fails
+```
+
+#### Messages
+
+```js
+assert.calledTwice.message = "Expected ${0} to be called twice but was called ${1}${2}";
+refute.calledTwice.message = "Expected ${0} to not be called exactly twice${2}";
+```
+
+<dl>
+    <dt>`${0}`:</dt>
+    <dd>The spy</dd>
+    <dt>`${1}`:</dt>
+    <dd>The number of calls, as a string. Ex: “two times”</dd>
+    <dt>`${2}`:</dt>
+    <dd>The call log. All calls as a string. Each line is one call and includes passed arguments, returned value and more</dd>
+</dl>
+
+### `calledThrice()`
+
+```js
+assert.calledThrice(spy)
+```
+
+Only passes if the `spy` has been called exactly three times.
+
+```js
+var spy = this.spy();
+
+assert.calledThrice(spy); // Fails
+
+spy();
+assert.calledThrice(spy); // Fails
+
+spy();
+assert.calledThrice(spy); // Fails
+
+spy();
+assert.calledThrice(spy); // Passes
+
+spy();
+assert.calledThrice(spy); // Fails
+```
+
+#### Messages
+
+```js
+assert.calledThrice.message = "Expected ${0} to be called thrice but was called ${1}${2}";
+refute.calledThrice.message = "Expected ${0} to not be called exactly thrice${2}";
+```
+
+<dl>
+    <dt>`${0}`:</dt>
+    <dd>The spy</dd>
+    <dt>`${1}`:</dt>
+    <dd>The number of calls, as a string. Ex: “two times”</dd>
+    <dt>`${2}`:</dt>
+    <dd>The call log. All calls as a string. Each line is one call and includes passed arguments, returned value and more</dd>
+</dl>
+
+### `calledOn()`
+
+```js
+assert.calledOn(spy, obj)
+```
+
+Passes if the `spy` was called at least once with `obj` as its `this` value.
+
+```js
+var spy = this.spy();
+var obj1 = {};
+var obj2 = {};
+var obj3 = {};
+
+spy.call(obj2);
+spy.call(obj3);
+
+assert.calledOn(spy, obj1); // Fails
+assert.calledOn(spy, obj2); // Passes
+assert.calledOn(spy, obj3); // Passes
+```
+
+#### Messages
+
+```js
+assert.calledOn.message = "Expected ${0} to be called with ${1} as this but was called on ${2}";
+refute.calledOn.message = "Expected ${0} not to be called with ${1} as this";
+```
+
+<dl>
+    <dt>`${0}`:</dt>
+    <dd>The spy</dd>
+    <dt>`${1}`:</dt>
+    <dd>The object obj which is expected to have been this at least once</dd>
+    <dt>`${2}`:</dt>
+    <dd>List of objects which actually have been `this`</dd>
+</dl>
+
+### `alwaysCalledOn()`
+
+```js
+assert.alwaysCalledOn(spy, obj)
+```
+
+Passes if the `spy` was always called with `obj` as its `this` value.
+
+```js
+var spy1 = this.spy();
+var spy2 = this.spy();
+var obj1 = {};
+var obj2 = {};
+
+spy1.call(obj1);
+spy1.call(obj2);
+
+spy2.call(obj2);
+spy2.call(obj2);
+
+assert.alwaysCalledOn(spy1, obj1); // Fails
+assert.alwaysCalledOn(spy1, obj2); // Fails
+assert.alwaysCalledOn(spy2, obj1); // Fails
+assert.alwaysCalledOn(spy2, obj2); // Passes
+```
+
+#### Messages
+
+```js
+assert.alwaysCalledOn.message = "Expected ${0} to always be called with ${1} as this but was called on ${2}";
+refute.alwaysCalledOn.message = "Expected ${0} not to always be called with ${1} as this";
+```
+
+<dl>
+    <dt>`${0}`:</dt>
+    <dd>The spy</dd>
+    <dt>`${1}`:</dt>
+    <dd>The object obj which is expected always to have been `this`</dd>
+    <dt>`${2}`:</dt>
+    <dd>List of objects which actually have been `this`</dd>
+</dl>
+
+
+### `calledWith()`
+
+```js
+assert.calledWith(spy, arg1, arg2, ...)
+```
+
+Passes if the `spy` was called at least once with the specified arguments. Other arguments may have been passed after the specified ones.
+
+```js
+var spy = this.spy();
+var arr = [1, 2, 3];
+spy(12);
+spy(42, 13);
+spy("Hey", arr, 2);
+
+assert.calledWith(spy, 12);         // Passes
+assert.calledWith(spy, "Hey");      // Passes
+assert.calledWith(spy, "Hey", 12);  // Fails
+assert.calledWith(spy, "Hey", arr); // Passes
+```
+
+#### Messages
+
+```js
+assert.calledWith.message = "Expected ${0} to be called with arguments ${1}${2}";
+refute.calledWith.message = "Expected ${0} not to be called with arguments ${1}${2}";
+```
+
+<dl>
+    <dt>`${0}`:</dt>
+    <dd>The spy</dd>
+    <dt>`${1}`:</dt>
+    <dd>The expected arguments</dd>
+    <dt>`${2}`:</dt>
+    <dd>String representation of all calls</dd>
+</dl>
+
+### `alwaysCalledWith()`
+
+```js
+assert.alwaysCalledWith(spy, arg1, arg2, ...)
+```
+
+Passes if the `spy` was always called with the specified arguments. Other arguments may have been passed after the specified ones.
+
+```js
+var spy = this.spy();
+var arr = [1, 2, 3];
+spy("Hey", arr, 12);
+spy("Hey", arr, 13);
+
+assert.alwaysCalledWith(spy, "Hey");          // Passes
+assert.alwaysCalledWith(spy, "Hey", arr);     // Passes
+assert.alwaysCalledWith(spy, "Hey", arr, 12); // Fails
+```
+
+#### Messages
+
+```js
+assert.alwaysCalledWith.message = "Expected ${0} to always be called with arguments ${1}${2}";
+refute.alwaysCalledWith.message = "Expected ${0} not to always be called with arguments${1}${2}";
+```
+
+<dl>
+    <dt>`${0}`:</dt>
+    <dd>The spy</dd>
+    <dt>`${1}`:</dt>
+    <dd>The expected arguments</dd>
+    <dt>`${2}`:</dt>
+    <dd>String representation of all calls</dd>
+</dl>
+
+### `calledOnceWith()`
+
+```js
+assert.calledOnceWith(spy, arg1, arg2, ...)
+```
+
+Passes if the `spy` was called exactly once and with the specified arguments. Other arguments may have been passed after the specified ones.
+
+```js
+var spy = this.spy();
+var arr = [1, 2, 3];
+spy(12);
+
+assert.calledOnceWith(spy, 12);     // Passes
+assert.calledOnceWith(spy, 42);     // Fails
+
+spy(42, 13);
+assert.calledOnceWith(spy, 42, 13); // Fails
+```
+
+#### Messages
+
+```js
+assert.calledOnceWith.message = "Expected ${0} to be called once with arguments ${1}${2}";
+refute.calledOnceWith.message = "Expected ${0} not to be called once with arguments ${1}${2}";
+```
+
+<dl>
+    <dt>`${0}`:</dt>
+    <dd>The spy</dd>
+    <dt>`${1}`:</dt>
+    <dd>The expected arguments</dd>
+    <dt>`${2}`:</dt>
+    <dd>String representation of all calls</dd>
+</dl>
+
+### `calledWithExactly()`
+
+```js
+assert.calledWithExactly(spy, arg1, arg2, ...)
+```
+
+Passes if the `spy` was called at least once with exactly the arguments specified.
+
+```js
+var spy = this.spy();
+var arr = [1, 2, 3];
+spy("Hey", arr, 12);
+spy("Hey", arr, 13);
+
+assert.calledWithExactly(spy, "Hey", arr, 12); // Passes
+assert.calledWithExactly(spy, "Hey", arr, 13); // Passes
+assert.calledWithExactly(spy, "Hey", arr);     // Fails
+assert.calledWithExactly(spy, "Hey");          // Fails
+```
+
+#### Messages
+
+```js
+assert.calledWithExactly.message = "Expected ${0} to be called with exact arguments ${1}${2}";
+refute.calledWithExactly.message = "Expected ${0} not to be called with exact arguments${1}${2}";
+```
+
+<dl>
+    <dt>`${0}`:</dt>
+    <dd>The spy</dd>
+    <dt>`${1}`:</dt>
+    <dd>The expected arguments</dd>
+    <dt>`${2}`:</dt>
+    <dd>String representation of all calls</dd>
+</dl>
+
+### `alwaysCalledWithExactly()`
+
+```js
+assert.alwaysCalledWithExactly(spy, arg1, arg2, ...)
+```
+
+Passes if the `spy` was always called with exactly the arguments specified.
+
+```js
+var spy = this.spy();
+var arr = [1, 2, 3];
+spy("Hey", arr, 12);
+
+assert.alwaysCalledWithExactly(spy, "Hey", arr, 12); // Passes
+assert.alwaysCalledWithExactly(spy, "Hey", arr);     // Fails
+assert.alwaysCalledWithExactly(spy, "Hey");          // Fails
+
+spy("Hey", arr, 13);
+assert.alwaysCalledWithExactly(spy, "Hey", arr, 12); // Fails
+```
+
+#### Messages
+
+```js
+assert.alwaysCalledWithExactly.message = "Expected ${0} to always be called with exact arguments ${1}${2}";
+refute.alwaysCalledWithExactly.message = "Expected ${0} not to always be called with exact arguments${1}${2}";
+```
+
+<dl>
+    <dt>`${0}`:</dt>
+    <dd>The spy</dd>
+    <dt>`${1}`:</dt>
+    <dd>The expected arguments</dd>
+    <dt>`${2}`:</dt>
+    <dd>String representation of all calls</dd>
+</dl>
+
+
+### `threw()`
+
+```js
+assert.threw(spy[, exception])
+```
+
+Passes if the `spy` threw at least once the specified `exception`. The `exception` can be a string denoting its type, or an actual object. If `exception` is not specified, the assertion passes if the `spy` ever threw any exception.
+
+```js
+var exception1 = new TypeError();
+var exception2 = new TypeError();
+var exception3 = new TypeError();
+var spy = this.spy(function(exception) {
+    throw exception;
+});
+
+function callAndCatchException(spy, exception) {
+    try {
+        spy(exception);
+    } catch(e) {
+    }
+}
+
+callAndCatchException(spy, exception1);
+callAndCatchException(spy, exception2);
+
+assert.threw(spy); // Passes
+assert.threw(spy, “TypeError”); // Passes
+assert.threw(spy, exception1); // Passes
+assert.threw(spy, exception2); // Passes
+assert.threw(spy, exception3); // Fails
+
+callAndCatchException(spy, exception3); assert.threw(spy, exception3); // Passes
+```
+
+#### Messages
+
+```js
+assert.threw.message = "Expected ${0} to throw an exception${1}";
+refute.threw.message = "Expected ${0} not to throw an exception${1}";
+```
+
+<dl>
+    <dt>`${0}`:</dt>
+    <dd>The spy</dd>
+    <dt>`${1}`:</dt>
+    <dd>The expected exception</dd>
+</dl>
+
+### `alwaysThrew()`
+
+```js
+assert.alwaysThrew(spy[, exception])
+```
+
+Passes if the `spy` always threw the specified `exception`. The `exception` can be a string denoting its type, or an actual object. If `exception` is not specified, the assertion passes if the `spy` ever threw any exception.
+
+```js
+var exception1 = new TypeError();
+var exception2 = new TypeError();
+var spy = this.spy(function(exception) {
+    throw exception;
+});
+
+function callAndCatchException(spy, exception) {
+    try {
+        spy(exception);
+    } catch(e) {
+
+    }
+}
+
+callAndCatchException(spy, exception1);
+assert.alwaysThrew(spy); // Passes
+assert.alwaysThrew(spy, “TypeError”); // Passes
+assert.alwaysThrew(spy, exception1); // Passes
+
+callAndCatchException(spy, exception2);
+assert.alwaysThrew(spy); // Passes
+assert.alwaysThrew(spy, “TypeError”); // Passes
+assert.alwaysThrew(spy, exception1); // Fails
+```
+
+#### Messages
+
+```js
+assert.alwaysThrew.message = "Expected ${0} to always throw an exception${1}";
+refute.alwaysThrew.message = "Expected ${0} not to always throw an exception${1}";
+```
+
+<dl>
+    <dt>`${0}`:</dt>
+    <dd>The spy</dd>
+    <dt>`${1}`:</dt>
+    <dd>The expected exception</dd>
+</dl>

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ The descriptions are for `assert`, but the corresponding failure messages for `r
 * [`calledOn()`](#calledon)
 * [`alwaysCalledOn()`](#alwayscalledon)
 * [`calledWith()`](#calledwith)
+* [`calledWithNew()`](#calledwithnew)
 * [`alwaysCalledWith()`](alwayscalledwith)
 * [`calledOnceWith()`](#calledoncewith)
 * [`calledWithExactly()`](#calledwithexactly)
@@ -375,6 +376,39 @@ refute.calledWith.message = "Expected ${0} not to be called with arguments ${1}$
     <dt>`${2}`:</dt>
     <dd>String representation of all calls</dd>
 </dl>
+
+### `calledWithNew()`
+
+```js
+assert.calledWithNew(spy)
+```
+
+Fails if the `spy` has never called with `new`.
+
+```js
+var spy = this.spy();
+
+assert.calledWithNew(spy); // Fails
+
+new spy();
+assert.calledWithNew(spy); // Passes
+
+spy();
+assert.calledWithNew(spy); // Passes
+```
+
+#### Messages
+
+```js
+assert.calledWithNew.message = "Expected ${spyObj} to be called with 'new' at least once but was never called with 'new'";
+refute.calledWithNew.message = "Expected ${spyObj} to not be called with 'new'";
+```
+
+<dl>
+    <dt>`${spyObj}`:</dt>
+    <dd>The spy</dd>
+</dl>
+
 
 ### `alwaysCalledWith()`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,22 @@
 
 Sinon.JS assertions for the referee assertion library.
 
+
+## Usage
+
+```shell
+npm install @sinonjs/referee-sinon --save-dev
+```
+
+```js
+const referee = require("referee");
+const sinon = require("sinon");
+
+// add the Sinon.JS assertions to referee
+require("@sinonjs/referee-sinon")(referee, sinon);
+```
+
+
 ## Assertions
 
 The descriptions are for `assert`, but the corresponding failure messages for `refute` are also mentioned. For refute the behaviour is exactly opposite.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ The descriptions are for `assert`, but the corresponding failure messages for `r
 * [`calledWith()`](#calledwith)
 * [`calledWithNew()`](#calledwithnew)
 * [`alwaysCalledWith()`](alwayscalledwith)
+* [`alwaysCalledWithNew()`](alwayscalledwithnew)
 * [`calledOnceWith()`](#calledoncewith)
 * [`calledWithExactly()`](#calledwithexactly)
 * [`alwaysCalledWithExactly()`](#alwayscalledwithexactly)
@@ -444,6 +445,39 @@ refute.alwaysCalledWith.message = "Expected ${0} not to always be called with ar
     <dt>`${2}`:</dt>
     <dd>String representation of all calls</dd>
 </dl>
+
+### `alwaysCalledWithNew()`
+
+```js
+assert.alwaysCalledWithNew(spy)
+```
+
+Passes when the `spy` has was always called with `new`
+
+```js
+var spy = this.spy();
+
+assert.alwaysCalledWithNew(spy); // Fails
+
+new spy();
+assert.alwaysCalledWithNew(spy); // Passes
+
+spy();
+assert.alwaysCalledWithNew(spy); // Fails
+```
+
+#### Messages
+
+```js
+assert.calledWithNew.message = "Expected ${spyObj} to always be called with 'new'";
+refute.calledWithNew.message = "Expected ${spyObj} to not always be called with 'new'";
+```
+
+<dl>
+    <dt>`${spyObj}`:</dt>
+    <dd>The spy</dd>
+</dl>
+
 
 ### `calledOnceWith()`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ The descriptions are for `assert`, but the corresponding failure messages for `r
 *Overview:*
 
 * [`called()`](#called)
+* [`callCount()`](#callcount)
 * [`callOrder()`](#callorder)
 * [`calledOnce()`](#calledonce)
 * [`calledTwice()`](#calledtwice)
@@ -67,6 +68,42 @@ refute.called.message = "Expected ${0} to not be called but was called ${1}${2}"
     <dt>`${2}`:</dt>
     <dd>All calls formatted as a multi-line string</dd>
 </dl>
+
+### `callCount()`
+
+```js
+assert.callCount(spy, count)
+```
+
+Fails if the `spy`'s `callCount` property is not exactly `count`
+
+```js
+var spy = this.spy();
+
+assert.callCount(spy, 0); // Passes
+assert.callCount(spy, 1); // Fails
+
+spy();
+assert.callCount(spy, 0); // Fails
+assert.callCount(spy, 1); // Passes
+```
+
+#### Messages
+
+```js
+assert.called.message = "Expected ${spyObj} to be called exactly ${expectedTimes} times, but was called ${actualTimes}";
+refute.called.message = "Expected ${spyObj} to not be called exactly ${expectedTimes} times"
+```
+
+<dl>
+    <dt>`${spyObj}`:</dt>
+    <dd>The spy</dd>
+    <dt>`${expectedTimes}`:</dt>
+    <dd>The expected number of calls</dd>
+    <dt>`${actualTimes}`:</dt>
+    <dd>The actual number of calls</dd>
+</dl>
+
 
 ### `callOrder()`
 

--- a/lib/referee-sinon.js
+++ b/lib/referee-sinon.js
@@ -16,6 +16,59 @@
 }(typeof self !== "undefined" ? self : this, function () {
     "use strict";
 
+    // lifted from https://github.com/sinonjs/sinon/blob/f89392c419dd3825d7af7fa0d58cc6ddeabfa3a6/lib/sinon/util/core/order-by-first-call.js
+    // FIXME: figure out how to share this code from Sinon
+    // * separate repository for this function?
+    // * Mono repo? https://lernajs.io
+    function orderByFirstCall(spies) {
+        return spies.sort(function (a, b) {
+            // uuid, won't ever be equal
+            var aCall = a.getCall(0);
+            var bCall = b.getCall(0);
+            var aId = aCall && aCall.callId || -1;
+            var bId = bCall && bCall.callId || -1;
+
+            return aId < bId ? -1 : 1;
+        });
+    }
+
+    // lifted from https://github.com/sinonjs/sinon/blob/f89392c419dd3825d7af7fa0d58cc6ddeabfa3a6/lib/sinon/util/core/called-in-order.js
+    // FIXME: figure out how to share this code from Sinon
+    // * separate repository for this function?
+    // * Mono repo? https://lernajs.io
+    var every = Array.prototype.every;
+
+    function calledInOrder(spies) {
+        var callMap = {};
+
+        function hasCallsLeft(spy) {
+            if (callMap[spy.id] === undefined) {
+                callMap[spy.id] = 0;
+            }
+
+            return callMap[spy.id] < spy.callCount;
+        }
+
+        if (arguments.length > 1) {
+            spies = arguments;
+        }
+
+        return every.call(spies, function checkAdjacentCalls(spy, i) {
+            var calledBeforeNext = true;
+
+            if (i !== spies.length - 1) {
+                calledBeforeNext = spy.calledBefore(spies[i + 1]);
+            }
+
+            if (hasCallsLeft(spy) && calledBeforeNext) {
+                callMap[spy.id] += 1;
+                return true;
+            }
+
+            return false;
+        });
+    }
+
     return function (referee, sinon) {
         sinon.expectation.pass = function (assertion) {
             referee.emit("pass", assertion);
@@ -79,6 +132,23 @@
 
             return [].slice.call(arr, from);
         }
+
+        referee.add("callOrder", {
+            assert: function (spy) {
+                var type = Object.prototype.toString.call(spy);
+                var isArray = type === "[object Array]";
+                var args = isArray ? spy : arguments;
+                verifyFakes.apply(this, args);
+                if (calledInOrder(args)) { return true; }
+
+                this.expected = [].join.call(args, ", ");
+                this.actual = orderByFirstCall(slice(args)).join(", ");
+                return false;
+            },
+
+            assertMessage: "Expected ${expected} to be called in order but were called as ${actual}",
+            refuteMessage: "Expected ${expected} not to be called in order"
+        });
 
         function addCallCountAssertion(count) {
             referee.add("called" + count, {

--- a/lib/referee-sinon.js
+++ b/lib/referee-sinon.js
@@ -70,6 +70,8 @@
     }
 
     return function (referee, sinon) {
+        var sf = sinon.spy.formatters;
+
         sinon.expectation.pass = function (assertion) {
             referee.emit("pass", assertion);
         };
@@ -103,8 +105,6 @@
 
             return true;
         }
-
-        var sf = sinon.spy.formatters;
 
         referee.add("called", {
             assert: function (spy) {

--- a/lib/referee-sinon.js
+++ b/lib/referee-sinon.js
@@ -140,6 +140,23 @@
             }
         });
 
+        referee.add("calledWithNew", {
+            assert: function (spy) {
+                verifyFakes.call(this, spy);
+                return spy.calledWithNew();
+            },
+            assertMessage: "Expected ${spyObj} to be called with 'new' at least once but was never called with 'new'",
+            refuteMessage: "Expected ${spyObj} to not be called with 'new'",
+            expectation: "toHaveBeenCalledWithNew",
+            values: function (spyObj) {
+                return {
+                    spyObj: spyObj,
+                    times: sf.c(spyObj),
+                    calls: sf.C(spyObj) // eslint-disable-line new-cap
+                };
+            }
+        });
+
         function slice(arr, from, to) {
 
             // don't pass "to" if not defined, because IE8 doesn't like that

--- a/lib/referee-sinon.js
+++ b/lib/referee-sinon.js
@@ -157,6 +157,23 @@
             }
         });
 
+        referee.add("alwaysCalledWithNew", {
+            assert: function (spy) {
+                verifyFakes.call(this, spy);
+                return spy.alwaysCalledWithNew();
+            },
+            assertMessage: "Expected ${spyObj} to always be called with 'new'",
+            refuteMessage: "Expected ${spyObj} to not always be called with 'new'",
+            expectation: "toAlwaysHaveBeenCalledWithNew",
+            values: function (spyObj) {
+                return {
+                    spyObj: spyObj,
+                    times: sf.c(spyObj),
+                    calls: sf.C(spyObj) // eslint-disable-line new-cap
+                };
+            }
+        });
+
         function slice(arr, from, to) {
 
             // don't pass "to" if not defined, because IE8 doesn't like that

--- a/lib/referee-sinon.js
+++ b/lib/referee-sinon.js
@@ -106,6 +106,23 @@
             return true;
         }
 
+        referee.add("callCount", {
+            assert: function (spy, count) {
+                verifyFakes.call(this, spy);
+                return spy.callCount === count;
+            },
+            assertMessage: "Expected ${spyObj} to be called exactly ${expectedTimes} times, but was called ${actualTimes}",
+            refuteMessage: "Expected ${spyObj} to not be called exactly ${expectedTimes} times",
+            expectation: "toHaveCallCount",
+            values: function (spyObj, count) {
+                return {
+                    spyObj: spyObj,
+                    actualTimes: sf.c(spyObj),
+                    expectedTimes: count
+                };
+            }
+        });
+
         referee.add("called", {
             assert: function (spy) {
                 verifyFakes.call(this, spy);

--- a/lib/referee-sinon.test.js
+++ b/lib/referee-sinon.test.js
@@ -19,7 +19,7 @@ referee.format = function () {
 };
 
 function requiresFunction(assertion) {
-    var args = [32].concat([].slice.call(arguments, 1));
+    var args = [32, "dummy argument"].concat([].slice.call(arguments, 1));
 
     return function () {
         assert.exception(function () {
@@ -33,7 +33,7 @@ function requiresFunction(assertion) {
 }
 
 function requiresSpy(assertion) {
-    var args = [function () {}].concat([].slice.call(arguments, 1));
+    var args = [function () {}, "dummy argument"].concat([].slice.call(arguments, 1));
 
     return function () {
         assert.exception(function () {

--- a/lib/referee-sinon.test.js
+++ b/lib/referee-sinon.test.js
@@ -288,6 +288,32 @@ describe("referee-sinon", function () {
             });
         });
 
+        describe("calledWithNew", function () {
+            it("fails when not called with function", requiresFunction("calledWithNew"));
+            it("fails when not called with spy", requiresSpy("calledWithNew"));
+
+            it("passes when called with new", function () {
+                var spy = sinon.spy();
+
+                // eslint-disable-next-line no-new, new-cap
+                new spy();
+
+                assert.calledWithNew(spy);
+            });
+
+            it("formats message", function () {
+                try {
+                    var spy = sinon.spy();
+                    spy();
+
+                    assert.calledWithNew(spy);
+                } catch (e) {
+                    var message = "[assert.calledWithNew] Expected function spy() {} to be called with 'new' at least once but was never called with 'new'";
+                    assert.equals(e.message, message);
+                }
+            });
+        });
+
         describe("callOrder", function () {
             it("fails when not called with function", requiresFunction("callOrder"));
             it("fails when not called with spy", requiresSpy("callOrder"));

--- a/lib/referee-sinon.test.js
+++ b/lib/referee-sinon.test.js
@@ -314,6 +314,37 @@ describe("referee-sinon", function () {
             });
         });
 
+        describe("alwaysCalledWithNew", function () {
+            it("fails when not called with function", requiresFunction("alwaysCalledWithNew"));
+            it("fails when not called with spy", requiresSpy("alwaysCalledWithNew"));
+
+            it("passes when always called with new", function () {
+                var spy = sinon.spy();
+
+                // eslint-disable-next-line no-new, new-cap
+                new spy();
+                // eslint-disable-next-line no-new, new-cap
+                new spy();
+                // eslint-disable-next-line no-new, new-cap
+                new spy();
+
+                assert.alwaysCalledWithNew(spy);
+            });
+
+            it("formats message", function () {
+                try {
+                    var spy = sinon.spy();
+                    spy();
+                    spy();
+
+                    assert.alwaysCalledWithNew(spy);
+                } catch (e) {
+                    var message = "[assert.alwaysCalledWithNew] Expected function spy() {} to always be called with 'new'";
+                    assert.equals(e.message, message);
+                }
+            });
+        });
+
         describe("callOrder", function () {
             it("fails when not called with function", requiresFunction("callOrder"));
             it("fails when not called with spy", requiresSpy("callOrder"));

--- a/lib/referee-sinon.test.js
+++ b/lib/referee-sinon.test.js
@@ -242,6 +242,29 @@ describe("referee-sinon", function () {
             });
         });
 
+        describe("callCount", function () {
+            it("fails when not called with function", requiresFunction("callCount"));
+            it("fails when not called with spy", requiresSpy("callCount"));
+
+            it("passes as callCount changes", function () {
+                var spy = sinon.spy();
+
+                for (var i = 1; i <= 100; i++) {
+                    spy(null, "Hey");
+                    assert.callCount(spy, i);
+                }
+            });
+
+            it("formats message nicely", function () {
+                try {
+                    assert.callCount(sinon.spy(), 1);
+                } catch (e) {
+                    var message = "[assert.callCount] Expected function spy() {} to be called exactly 1 times, but was called 0 times";
+                    assert.match(e.message, message);
+                }
+            });
+        });
+
         describe("called", function () {
             it("fails when not called with function", requiresFunction("called"));
             it("fails when not called with spy", requiresSpy("called"));

--- a/lib/referee-sinon.test.js
+++ b/lib/referee-sinon.test.js
@@ -231,6 +231,41 @@ describe("referee-sinon", function () {
             });
         });
 
+        describe("callOrder", function () {
+            it("fails when not called with function", requiresFunction("callOrder"));
+            it("fails when not called with spy", requiresSpy("callOrder"));
+
+            it("passes when called in order", function () {
+                var spies = [sinon.spy(), sinon.spy()];
+                spies[0]();
+                spies[1]();
+
+                assert.callOrder(spies[0], spies[1]);
+            });
+
+            it("passes when called in order using an array", function () {
+                var spies = [sinon.spy(), sinon.spy()];
+                spies[0]();
+                spies[1]();
+
+                assert.callOrder(spies);
+            });
+
+            it("formats message", function () {
+                var spies = [sinon.spy(), sinon.spy()];
+                spies[1]();
+                spies[0]();
+
+                try {
+                    assert.callOrder(spies[0], spies[1]);
+                } catch (e) {
+                    var message = "[assert.callOrder] Expected 0, 1 to be " +
+                            "called in order but were called as 1, 0";
+                    assert.equals(e.message, message);
+                }
+            });
+        });
+
         describe("calledOn", function () {
             it("fails when not called with function", requiresFunction("calledOn", {}));
             it("fails when not called with spy", requiresSpy("calledOn", {}));

--- a/lib/referee-sinon.test.js
+++ b/lib/referee-sinon.test.js
@@ -107,9 +107,9 @@ describe("referee-sinon", function () {
 
             it("passes when spy is explicitly passed null", function () {
                 var spy = sinon.spy();
-                spy(null, "Hey");
+                spy(null, "Hey!");
 
-                refute.calledWith(spy, null, "Hey!");
+                assert.calledWith(spy, null, "Hey!");
             });
 
             it("formats message nicely", function () {
@@ -142,9 +142,9 @@ describe("referee-sinon", function () {
 
             it("passes when spy is explicitly passed null", function () {
                 var spy = sinon.spy();
-                spy(null, "Hey");
+                spy(null, "Hey!");
 
-                refute.calledWithExactly(spy, null, "Hey!");
+                assert.calledWithExactly(spy, null, "Hey!");
             });
 
             it("formats message nicely", function () {
@@ -168,9 +168,12 @@ describe("referee-sinon", function () {
 
             it("passes when spy is passed matching object", function () {
                 var spy = sinon.spy();
-                spy({ check: 123 });
+                spy({
+                    check: 123,
+                    color: "#fff"
+                });
 
-                refute.calledWithMatch(spy, { test: 123 });
+                assert.calledWithMatch(spy, { check: 123 });
             });
 
             it("formats message nicely", function () {
@@ -194,10 +197,16 @@ describe("referee-sinon", function () {
 
             it("passes when spy is always passed matching object", function () {
                 var spy = sinon.spy();
-                spy({ check: 123 });
-                spy({ check: 321 });
+                spy({
+                    check: 123,
+                    color: "#aaa"
+                });
+                spy({
+                    check: 123,
+                    color: "#bbb"
+                });
 
-                refute.alwaysCalledWithMatch(spy, { test: 123 });
+                assert.alwaysCalledWithMatch(spy, { check: 123 });
             });
 
             it("formats message nicely", function () {

--- a/lib/referee-sinon.test.js
+++ b/lib/referee-sinon.test.js
@@ -51,6 +51,40 @@ describe("referee-sinon", function () {
         sandbox.restore();
     });
 
+    describe("mapping", function () {
+        var DISALLOWED_METHODS = [
+            "expose",
+            "fail",
+            // this can be achieved with refute.calledWith
+            "neverCalledWith",
+            // this can be achieved with refute.calledWithMatch
+            "neverCalledWithMatch",
+            // this can be achieved with refute.called
+            "notCalled",
+            "pass"
+        ];
+        var sinonMethods = Object.keys(sinon.assert).filter(function (key) {
+            var isDisallowed = DISALLOWED_METHODS.indexOf(key) !== -1;
+            var isFunction = typeof sinon.assert[key] === "function";
+
+            return !isDisallowed && isFunction;
+        });
+
+        sinonMethods.forEach(function (methodName) {
+            it("should map '" + methodName + "' from sinon.assert", function () {
+                assert.isFunction(referee.assert[methodName]);
+                assert.isFunction(referee.refute[methodName]);
+            });
+        });
+
+        DISALLOWED_METHODS.forEach(function (methodName) {
+            it("must not map disallowed '" + methodName + "' from sinon.assert", function () {
+                refute.defined(referee.assert[methodName]);
+                refute.defined(referee.refute[methodName]);
+            });
+        });
+    });
+
     describe("assertions", function () {
         it("formats assert messages through referee", function () {
             sandbox.stub(referee, "format").returns("I'm the object");

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,3 @@
+site_name: referee-sinon
+theme: readthedocs
+repo_url: https://github.com/sinonjs/referee-sinon/

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "lint": "eslint .",
     "precommit": "lint-staged",
+    "prepublishOnly": "mkdocs gh-deploy -r upstream || mkdocs gh-deploy -r origin",
     "test": "mocha 'lib/**/*.test.js'",
     "test-coverage": "nyc --reporter text --reporter html --reporter lcovonly npm run test"
   },


### PR DESCRIPTION
Fixes #8 

This PR is aimed at ensuring that when using `referee-sinon` with modern Sinon, all the assertions from `sinon` are also available in `referee`.

It implements a test that verifies that all assertions on `sinon.assert` are also present on `referee.assert`.

#### Bonus commit

Re-add `refereree.assert.callOrder` by stealing some code from Sinon (I mistakenly removed it in an earlier commit, that was merged as part of #7).

#### Missing assertions

When using `sinon@4.4.2`, these assertions are missing:

* `callCount` (implemented in PR)
* ~`notCalled`~ (won't implement, this can be done with `refereree.refute.called`)
* `calledWithNew` (implemented in PR)
* `alwaysCalledWithNew` (implemented in PR)
* ~`neverCalledWith`~ (won't implement, this can be done with `refereree.refute.calledWith`)
* ~`neverCalledWithMatch`~ (won't implement, this can be done with `refereree.refute.calledWithMatch`)