### PR TITLE
Add files directive to package.json to control what goes to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
   "lint-staged": {
     "*.js": "eslint"
   },
+  "files": [
+    "docs/",
+    "lib/",
+    "!lib/**/*.test.js"
+  ],
   "devDependencies": {
     "@sinonjs/formatio": "^2.0.0",
     "eslint": "^4.18.1",


### PR DESCRIPTION
Used negate expressions in `package.json` files entry, although it goes
against recommendation below, because that's the only thing that
worked. Read the github references below for details.

> "The consequences are undefined" if you try to negate any of the files
> entries (that is, "!foo.js"). Please don't. Use .npmignore.

https://github.com/npm/npm/wiki/Files-and-Ignores#details

```text
.
├── LICENSE
├── README.md
├── docs
│   └── index.md
├── lib
│   └── referee-sinon.js
└── package.json
```

#### How to verify

This uses [`tree`](https://en.wikipedia.org/wiki/Tree_(Unix)), on macOS install it using `brew install tree`

1. Check out this branch
1. `npm install`
1. `npm pack`
1. Unpack the `sinonjs-referee-2.0.0.tgz` just created
1. `cd package`
1. `tree .`
1. Observe that you see the same as the example above