### PR TITLE
Support spy calls in assertions

### DIFF
--- a/lib/referee-sinon.js
+++ b/lib/referee-sinon.js
@@ -101,10 +101,7 @@ function verifyFakes() {
         isNot = (method || "fake") + " is not ";
 
         if (!method) { this.fail(isNot + "a spy"); }
-        if (typeof method !== "function") {
-            this.fail(isNot + "a function");
-        }
-        if (typeof method.getCall !== "function") {
+        if (typeof method.calledWith !== "function") {
             this.fail(isNot + "stubbed");
         }
     }

--- a/lib/referee-sinon.test.js
+++ b/lib/referee-sinon.test.js
@@ -19,20 +19,6 @@ referee.format = function () {
     return formatter.ascii.apply(formatter, arguments);
 };
 
-function requiresFunction(assertion) {
-    var args = [32, "dummy argument"].concat([].slice.call(arguments, 1));
-
-    return function () {
-        assert.exception(function () {
-            assert[assertion].apply(assert, args);
-        }, {message: "32 is not a function"});
-
-        assert.exception(function () {
-            refute[assertion].apply(assert, args);
-        }, {message: "32 is not a function"});
-    };
-}
-
 function requiresSpy(assertion) {
     var args = [function () {}, "dummy argument"].concat([].slice.call(arguments, 1));
 
@@ -109,7 +95,6 @@ describe("referee-sinon", function () {
         });
 
         describe("calledWith", function () {
-            it("fails when not called with function", requiresFunction("calledWith"));
             it("fails when not called with spy", requiresSpy("calledWith"));
 
             it("passes when spy is explicitly passed null", function () {
@@ -142,10 +127,16 @@ describe("referee-sinon", function () {
                 assert.calledWith(spy, "foo");
                 assert.calledWithExactly(Array.prototype.slice, 1);
             });
+
+            it("works with spy calls", function () {
+                var spy = sinon.spy();
+                spy(null, "Hey!");
+
+                assert.calledWith(spy.firstCall, null, "Hey!");
+            });
         });
 
         describe("calledWithExactly", function () {
-            it("fails when not called with function", requiresFunction("calledWithExactly"));
             it("fails when not called with spy", requiresSpy("calledWithExactly"));
 
             it("passes when spy is explicitly passed null", function () {
@@ -169,10 +160,16 @@ describe("referee-sinon", function () {
                     assert.match(e.message, message);
                 }
             });
+
+            it("works with spy calls", function () {
+                var spy = sinon.spy();
+                spy(null, "Hey!");
+
+                assert.calledWithExactly(spy.firstCall, null, "Hey!");
+            });
         });
 
         describe("calledWithMatch", function () {
-            it("fails when not called with function", requiresFunction("calledWithMatch"));
             it("fails when not called with spy", requiresSpy("calledWithMatch"));
 
             it("passes when spy is passed matching object", function () {
@@ -199,10 +196,19 @@ describe("referee-sinon", function () {
                     assert.match(e.message, message);
                 }
             });
+
+            it("works with spy calls", function () {
+                var spy = sinon.spy();
+                spy({
+                    check: 123,
+                    color: "#fff"
+                });
+
+                assert.calledWithMatch(spy.firstCall, { check: 123 });
+            });
         });
 
         describe("alwaysCalledWithMatch", function () {
-            it("fails when not called with function", requiresFunction("alwaysCalledWithMatch"));
             it("fails when not called with spy", requiresSpy("alwaysCalledWithMatch"));
 
             it("passes when spy is always passed matching object", function () {
@@ -241,7 +247,6 @@ describe("referee-sinon", function () {
         });
 
         describe("calledOnce", function () {
-            it("fails when not called with function", requiresFunction("calledOnce"));
             it("fails when not called with spy", requiresSpy("calledOnce"));
 
             it("passes when called once", function () {
@@ -264,7 +269,6 @@ describe("referee-sinon", function () {
         });
 
         describe("calledTwice", function () {
-            it("fails when not called with function", requiresFunction("calledTwice"));
             it("fails when not called with spy", requiresSpy("calledTwice"));
 
             it("passes when called twice", function () {
@@ -292,7 +296,6 @@ describe("referee-sinon", function () {
         });
 
         describe("calledThrice", function () {
-            it("fails when not called with function", requiresFunction("calledThrice"));
             it("fails when not called with spy", requiresSpy("calledThrice"));
 
             it("passes when called thrice", function () {
@@ -323,7 +326,6 @@ describe("referee-sinon", function () {
         });
 
         describe("callCount", function () {
-            it("fails when not called with function", requiresFunction("callCount"));
             it("fails when not called with spy", requiresSpy("callCount"));
 
             it("passes as callCount changes", function () {
@@ -347,7 +349,6 @@ describe("referee-sinon", function () {
         });
 
         describe("called", function () {
-            it("fails when not called with function", requiresFunction("called"));
             it("fails when not called with spy", requiresSpy("called"));
 
             it("passes when called once", function () {
@@ -371,7 +372,6 @@ describe("referee-sinon", function () {
         });
 
         describe("calledWithNew", function () {
-            it("fails when not called with function", requiresFunction("calledWithNew"));
             it("fails when not called with spy", requiresSpy("calledWithNew"));
 
             it("passes when called with new", function () {
@@ -395,10 +395,18 @@ describe("referee-sinon", function () {
                     assert.equals(e.message, message);
                 }
             });
+
+            it("works with spy calls", function () {
+                var spy = sinon.spy();
+
+                // eslint-disable-next-line no-new, new-cap
+                new spy();
+
+                assert.calledWithNew(spy.firstCall);
+            });
         });
 
         describe("alwaysCalledWithNew", function () {
-            it("fails when not called with function", requiresFunction("alwaysCalledWithNew"));
             it("fails when not called with spy", requiresSpy("alwaysCalledWithNew"));
 
             it("passes when always called with new", function () {
@@ -430,7 +438,6 @@ describe("referee-sinon", function () {
         });
 
         describe("callOrder", function () {
-            it("fails when not called with function", requiresFunction("callOrder"));
             it("fails when not called with spy", requiresSpy("callOrder"));
 
             it("passes when called in order", function () {
@@ -466,7 +473,6 @@ describe("referee-sinon", function () {
         });
 
         describe("calledOn", function () {
-            it("fails when not called with function", requiresFunction("calledOn", {}));
             it("fails when not called with spy", requiresSpy("calledOn", {}));
 
             it("passes when called on object", function () {
@@ -492,10 +498,17 @@ describe("referee-sinon", function () {
                     assert.equals(e.message, message);
                 }
             });
+
+            it("works with spy calls", function () {
+                var spy = sinon.spy();
+                var object = { id: 42 };
+                spy.call(object);
+
+                assert.calledOn(spy.firstCall, object);
+            });
         });
 
         describe("alwaysCalledOn", function () {
-            it("fails when not called with function", requiresFunction("alwaysCalledOn", {}));
             it("fails when not called with spy", requiresSpy("alwaysCalledOn", {}));
 
             it("passes when called on object", function () {
@@ -524,7 +537,6 @@ describe("referee-sinon", function () {
         });
 
         describe("alwaysCalledWith", function () {
-            it("fails when not called with function", requiresFunction("alwaysCalledWith"));
             it("fails when not called with spy", requiresSpy("alwaysCalledWith"));
 
             it("passes when always called with same value", function () {
@@ -552,7 +564,6 @@ describe("referee-sinon", function () {
         });
 
         describe("alwaysCalledWithExactly", function () {
-            it("fails when not called with function", requiresFunction("alwaysCalledWithExactly"));
             it("fails when not called with spy", requiresSpy("alwaysCalledWithExactly"));
 
             it("fails when spy is explicitly passed null", function () {
@@ -579,7 +590,6 @@ describe("referee-sinon", function () {
         });
 
         describe("threw", function () {
-            it("fails when not called with function", requiresFunction("threw"));
             it("fails when not called with spy", requiresSpy("threw"));
 
             it("passes when spy threw", function () {
@@ -603,10 +613,18 @@ describe("referee-sinon", function () {
                     assert.match(e.message, message);
                 }
             });
+
+            it("works with spy calls", function () {
+                var spy = sandbox.stub().throws();
+                try {
+                    spy();
+                // eslint-disable-next-line no-empty
+                } catch (e) {}
+                assert.threw(spy.firstCall);
+            });
         });
 
         describe("alwaysThrew", function () {
-            it("fails when not called with function", requiresFunction("alwaysThrew"));
             it("fails when not called with spy", requiresSpy("alwaysThrew"));
 
             it("passes when spy always threw", function () {
@@ -633,7 +651,6 @@ describe("referee-sinon", function () {
         });
 
         describe("calledOnceWith", function () {
-            it("fails when not called with function", requiresFunction("calledOnceWith"));
             it("fails when not called with spy", requiresSpy("calledOnceWith"));
 
 


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

This allows to pass a call as the first argument to sinon assertions,
e.g. `assert.calledWith(spy.firstCall, 123)`. This is supported by Sinon
but wasn't working with this library because of the argument validateion
being too restrictive.

#### Solution  - optional

This change removes the `typeof "function"` check in `verifyFakes` and checks if the given argument supports `calledWith` instead of checking for `getCall`.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm t`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
