### PR TITLE
Import @sinonjs/commons

### DIFF
--- a/lib/referee-sinon.js
+++ b/lib/referee-sinon.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var calledInOrder = require("@sinonjs/commons").calledInOrder;
 var orderByFirstCall = require("@sinonjs/commons").orderByFirstCall;
 var referee = require("@sinonjs/referee");
 var sinon = require("sinon");
@@ -24,43 +25,6 @@ function callsToString(fake) {
     }
 
     return calls.length > 0 ? "\n" + calls.join("\n") : "";
-}
-
-// lifted from https://github.com/sinonjs/sinon/blob/f89392c419dd3825d7af7fa0d58cc6ddeabfa3a6/lib/sinon/util/core/called-in-order.js
-// FIXME: figure out how to share this code from Sinon
-// * separate repository for this function?
-// * Mono repo? https://lernajs.io
-var every = Array.prototype.every;
-
-function calledInOrder(spies) {
-    var callMap = {};
-
-    function hasCallsLeft(spy) {
-        if (callMap[spy.id] === undefined) {
-            callMap[spy.id] = 0;
-        }
-
-        return callMap[spy.id] < spy.callCount;
-    }
-
-    if (arguments.length > 1) {
-        spies = arguments;
-    }
-
-    return every.call(spies, function checkAdjacentCalls(spy, i) {
-        var calledBeforeNext = true;
-
-        if (i !== spies.length - 1) {
-            calledBeforeNext = spy.calledBefore(spies[i + 1]);
-        }
-
-        if (hasCallsLeft(spy) && calledBeforeNext) {
-            callMap[spy.id] += 1;
-            return true;
-        }
-
-        return false;
-    });
 }
 
 sinon.expectation.pass = function (assertion) {

--- a/lib/referee-sinon.js
+++ b/lib/referee-sinon.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var orderByFirstCall = require("@sinonjs/commons").orderByFirstCall;
 var referee = require("@sinonjs/referee");
 var sinon = require("sinon");
 
@@ -23,22 +24,6 @@ function callsToString(fake) {
     }
 
     return calls.length > 0 ? "\n" + calls.join("\n") : "";
-}
-
-// lifted from https://github.com/sinonjs/sinon/blob/f89392c419dd3825d7af7fa0d58cc6ddeabfa3a6/lib/sinon/util/core/order-by-first-call.js
-// FIXME: figure out how to share this code from Sinon
-// * separate repository for this function?
-// * Mono repo? https://lernajs.io
-function orderByFirstCall(spies) {
-    return spies.sort(function (a, b) {
-        // uuid, won't ever be equal
-        var aCall = a.getCall(0);
-        var bCall = b.getCall(0);
-        var aId = aCall && aCall.callId || -1;
-        var bId = bCall && bCall.callId || -1;
-
-        return aId < bId ? -1 : 1;
-    });
 }
 
 // lifted from https://github.com/sinonjs/sinon/blob/f89392c419dd3825d7af7fa0d58cc6ddeabfa3a6/lib/sinon/util/core/called-in-order.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,14 @@
         "js-tokens": "^3.0.0"
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.2.0.tgz",
+      "integrity": "sha512-oZEHtyTw+Xnj7hra125osc2mxsecQ6r7XD2gQrtULn4+orMf8rlqTtMVRoKFpZIB2Bfzxzs/Fgc8LdZ+dgDdzg==",
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
     "@sinonjs/formatio": {
       "version": "2.0.0",
       "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "rollup-plugin-commonjs": "^8.3.0"
   },
   "dependencies": {
+    "@sinonjs/commons": "^1.2.0",
     "@sinonjs/referee": "^2.1.1",
     "sinon": "^6.0.0"
   }


### PR DESCRIPTION
Fix #13

This PR replaces two functions that were duplicated from `sinon` with the same functions that have been extracted to `@sinonjs/commons`.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
