### PR TITLE
Referee v3 sinon v7

### DIFF
--- a/lib/referee-sinon.js
+++ b/lib/referee-sinon.js
@@ -44,9 +44,9 @@ var formatter = formatio.configure({
     limitChildrenCount: 250
 });
 
-var format = function () {
+function format() {
     return formatter.ascii.apply(formatter, arguments);
-};
+}
 
 referee.setFormatter(format);
 sinon.setFormatter(format);

--- a/lib/referee-sinon.js
+++ b/lib/referee-sinon.js
@@ -3,6 +3,7 @@
 var calledInOrder = require("@sinonjs/commons").calledInOrder;
 var orderByFirstCall = require("@sinonjs/commons").orderByFirstCall;
 var referee = require("@sinonjs/referee");
+var formatio = require("@sinonjs/formatio");
 var sinon = require("sinon");
 
 var timesInWords = [null, "once", "twice", "thrice"];
@@ -38,9 +39,17 @@ sinon.expectation.fail = function (message) {
 // Lazy bind the format method to referee's. This way, Sinon will
 // always format objects like referee does, even if referee is
 // configured after referee-sinon is loaded
-sinon.format = function () {
-    return referee.format.apply(referee, arguments);
+var formatter = formatio.configure({
+    quoteStrings: false,
+    limitChildrenCount: 250
+});
+
+var format = function () {
+    return formatter.ascii.apply(formatter, arguments);
 };
+
+referee.setFormatter(format);
+sinon.setFormatter(format);
 
 function verifyFakes() {
     var method, isNot, i, l;
@@ -206,7 +215,7 @@ referee.add("alwaysCalledOn", {
 function formattedArgs(args, i) {
     var l, result;
     for (l = args.length, result = []; i < l; ++i) {
-        push.call(result, sinon.format(args[i]));
+        push.call(result, format(args[i]));
     }
     return result.join(", ");
 }

--- a/lib/referee-sinon.test.js
+++ b/lib/referee-sinon.test.js
@@ -4,8 +4,6 @@ var sinon = require("sinon");
 var referee = require("@sinonjs/referee");
 var formatio = require("@sinonjs/formatio");
 
-var sandbox = sinon.createSandbox();
-
 var assert = referee.assert;
 var refute = referee.refute;
 var expect = referee.expect;
@@ -35,7 +33,7 @@ function requiresSpy(assertion) {
 
 describe("referee-sinon", function () {
     afterEach(function () {
-        sandbox.restore();
+        sinon.restore();
     });
 
     describe("sinon", function () {
@@ -80,7 +78,7 @@ describe("referee-sinon", function () {
 
     describe("assertions", function () {
         it("formats assert messages through referee", function () {
-            sandbox.stub(referee, "format").returns("I'm the object");
+            sinon.stub(referee, "format").returns("I'm the object");
             var message;
             var spy = sinon.spy();
             spy({ id: 42 });
@@ -122,7 +120,7 @@ describe("referee-sinon", function () {
             it("doesn't pass undefined to [].slice (IE8 doesn't like that)", function () {
                 var spy = sinon.spy();
                 spy("foo");
-                sandbox.spy(Array.prototype, "slice");
+                sinon.spy(Array.prototype, "slice");
 
                 assert.calledWith(spy, "foo");
                 assert.calledWithExactly(Array.prototype.slice, 1);
@@ -593,7 +591,7 @@ describe("referee-sinon", function () {
             it("fails when not called with spy", requiresSpy("threw"));
 
             it("passes when spy threw", function () {
-                var spy = sandbox.stub().throws();
+                var spy = sinon.stub().throws();
                 try {
                     spy();
                 // eslint-disable-next-line no-empty
@@ -615,7 +613,7 @@ describe("referee-sinon", function () {
             });
 
             it("works with spy calls", function () {
-                var spy = sandbox.stub().throws();
+                var spy = sinon.stub().throws();
                 try {
                     spy();
                 // eslint-disable-next-line no-empty
@@ -628,7 +626,7 @@ describe("referee-sinon", function () {
             it("fails when not called with spy", requiresSpy("alwaysThrew"));
 
             it("passes when spy always threw", function () {
-                var spy = sandbox.stub().throws();
+                var spy = sinon.stub().throws();
                 try {
                     spy();
                 // eslint-disable-next-line no-empty
@@ -698,7 +696,7 @@ describe("referee-sinon", function () {
 
     describe("expectations", function () {
         it("toHaveBeenCalledWithMatch", function () {
-            var stub = sandbox.stub(assert, "calledWithMatch");
+            var stub = sinon.stub(assert, "calledWithMatch");
 
             expect().toHaveBeenCalledWithMatch();
 
@@ -706,7 +704,7 @@ describe("referee-sinon", function () {
         });
 
         it("toHaveAlwaysBeenCalledWithMatch", function () {
-            var stub = sandbox.stub(assert, "alwaysCalledWithMatch");
+            var stub = sinon.stub(assert, "alwaysCalledWithMatch");
 
             expect().toHaveAlwaysBeenCalledWithMatch();
 
@@ -716,7 +714,7 @@ describe("referee-sinon", function () {
 
     describe("sinon assert failures", function () {
         it("delegates to referee.assert.fail", function () {
-            sandbox.stub(referee, "fail");
+            sinon.stub(referee, "fail");
 
             try {
                 assert.calledOnce(sinon.spy());
@@ -743,7 +741,7 @@ describe("referee-sinon", function () {
 
     describe("sinon mock expectation failures", function () {
         it("delegates to referee.assert.fail", function () {
-            sandbox.stub(referee, "fail");
+            sinon.stub(referee, "fail");
 
             try {
                 sinon.mock().never()();

--- a/lib/referee-sinon.test.js
+++ b/lib/referee-sinon.test.js
@@ -77,8 +77,8 @@ describe("referee-sinon", function () {
     });
 
     describe("assertions", function () {
-        it("formats assert messages through referee", function () {
-            sinon.stub(referee, "format").returns("I'm the object");
+        it("formats assert messages through formatio", function () {
+            sinon.stub(formatio, "ascii").returns("I'm the object");
             var message;
             var spy = sinon.spy();
             spy({ id: 42 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6703,7 +6703,7 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
     },
     "text-table": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,33 +79,44 @@
       }
     },
     "@sinonjs/commons": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.2.0.tgz",
-      "integrity": "sha512-oZEHtyTw+Xnj7hra125osc2mxsecQ6r7XD2gQrtULn4+orMf8rlqTtMVRoKFpZIB2Bfzxzs/Fgc8LdZ+dgDdzg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+      "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
       "requires": {
         "type-detect": "4.0.8"
       }
     },
     "@sinonjs/formatio": {
-      "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
+      "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
       "requires": {
-        "samsam": "1.3.0"
+        "@sinonjs/samsam": "^2 || ^3"
       }
     },
     "@sinonjs/referee": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-2.1.1.tgz",
-      "integrity": "sha512-plsDNXJdEtE7TAqgaeojagzzh+vUrZzqNeSL7y6GjvfQfG9ItgNiu5qIX1enrYyJJdJoiUQAgmasZhHMT7O0Ig==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-3.0.0.tgz",
+      "integrity": "sha512-wIeVkSAtfUX4VEgYA2RuzE/5OU/1OtC6yYpFUhvUnFF6TR2BUkcmz+4KxGghCwjR7Dempe8tGx27flvHgoBqXw==",
       "requires": {
-        "array.from": "^1.0.3",
+        "@sinonjs/commons": "^1.3.0",
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/samsam": "^3.0.0",
+        "array-from": "2.1.1",
         "bane": "^1.x",
-        "es6-promise": "^4.2.4",
         "lodash.includes": "^4.3.0",
         "lodash.isarguments": "^3.1.0",
-        "object-assign": "^4.1.1",
-        "samsam": "^1.x"
+        "object-assign": "^4.1.1"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.0.2.tgz",
+      "integrity": "sha512-m08g4CS3J6lwRQk1pj1EO+KEVWbrbXsmi9Pw0ySmrIbcVxVaedoFgLvFsV8wHLwh01EpROVz3KvVcD1Jmks9FQ==",
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash.get": "^4.4.2"
       }
     },
     "acorn": {
@@ -209,6 +220,11 @@
       "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
       "dev": true
     },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
+    },
     "array-map": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
@@ -241,15 +257,6 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true
-    },
-    "array.from": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array.from/-/array.from-1.0.3.tgz",
-      "integrity": "sha1-y1hqrZIGfzQSKfQeDtZDKB26Vrc=",
-      "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.6.1"
-      }
     },
     "arrify": {
       "version": "1.0.1",
@@ -754,6 +761,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
       "requires": {
         "foreach": "^2.0.5",
         "object-keys": "^1.0.8"
@@ -875,6 +883,7 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
       "integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
+      "dev": true,
       "requires": {
         "es-to-primitive": "^1.1.1",
         "function-bind": "^1.1.1",
@@ -887,16 +896,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.1",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.1"
       }
-    },
-    "es6-promise": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1252,7 +1257,8 @@
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -1278,7 +1284,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -1421,6 +1428,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
       "requires": {
         "function-bind": "^1.0.2"
       }
@@ -1647,7 +1655,8 @@
     "is-callable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
     },
     "is-ci": {
       "version": "1.1.0",
@@ -1670,7 +1679,8 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -1826,6 +1836,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -1851,7 +1862,8 @@
     "is-symbol": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -1946,9 +1958,9 @@
       "dev": true
     },
     "just-extend": {
-      "version": "1.1.27",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-3.0.0.tgz",
+      "integrity": "sha512-Fu3T6pKBuxjWT/p4DkqGHFRsysc8OauWr4ZRTY9dIx07Y9O0RkoR5jcv28aeD1vuAwhm3nLkDurwLXoALp4DpQ=="
     },
     "kind-of": {
       "version": "3.2.2",
@@ -2319,9 +2331,9 @@
       }
     },
     "lolex": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.0.tgz",
-      "integrity": "sha512-uJkH2e0BVfU5KOJUevbTOtpDduooSarH5PopO+LfM/vZf8Z9sJzODqKev804JYM2i++ktJfUmC1le4LwFQ1VMg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.0.0.tgz",
+      "integrity": "sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ=="
     },
     "lru-cache": {
       "version": "4.1.2",
@@ -2826,15 +2838,22 @@
       "dev": true
     },
     "nise": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.2.tgz",
-      "integrity": "sha512-BxH/DxoQYYdhKgVAfqVy4pzXRZELHOIewzoesxpjYvpU+7YOalQhGNPf7wAx8pLrTNPrHRDlLOkAl8UI0ZpXjw==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.7.tgz",
+      "integrity": "sha512-5cxvo/pEAEHBX5s0zl+zd96BvHHuua/zttIHeQuTWSDjGrWsEHamty8xbZNfocC+fx7NMrle7XHvvxtFxobIZQ==",
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "just-extend": "^1.1.27",
+        "@sinonjs/formatio": "^3.1.0",
+        "just-extend": "^3.0.0",
         "lolex": "^2.3.2",
         "path-to-regexp": "^1.7.0",
         "text-encoding": "^0.6.4"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q=="
+        }
       }
     },
     "normalize-package-data": {
@@ -5578,7 +5597,8 @@
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -6203,11 +6223,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
-    "samsam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
-    },
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
@@ -6303,17 +6318,27 @@
       }
     },
     "sinon": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.0.0.tgz",
-      "integrity": "sha512-MatciKXyM5pXMSoqd593MqTsItJNCkSSl53HJYeKR5wfsDdp2yljjUQJLfVwAWLoBNfx1HThteqygGQ0ZEpXpQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.2.0.tgz",
+      "integrity": "sha512-N+ebPVqU55E6IUUGPSia57D5nTlCjfxrVR/33KTMRjsJJP5ZoGW1TXyLa2kDREgMtzqdnnksv7gA9oGC2v2LGw==",
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
+        "@sinonjs/commons": "^1.2.0",
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/samsam": "^3.0.1",
         "diff": "^3.5.0",
-        "lodash.get": "^4.4.2",
-        "lolex": "^2.4.2",
-        "nise": "^1.3.3",
-        "supports-color": "^5.4.0",
-        "type-detect": "^4.0.8"
+        "lolex": "^3.0.0",
+        "nise": "^1.4.7",
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "slice-ansi": {
@@ -6651,6 +6676,7 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -6677,7 +6703,7 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
     },
     "text-table": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,9 +95,9 @@
       }
     },
     "@sinonjs/referee": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-3.0.0.tgz",
-      "integrity": "sha512-wIeVkSAtfUX4VEgYA2RuzE/5OU/1OtC6yYpFUhvUnFF6TR2BUkcmz+4KxGghCwjR7Dempe8tGx27flvHgoBqXw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-3.1.0.tgz",
+      "integrity": "sha512-pffyjv3DFFOlq/ti/pfjPE6H7gwtLSg3GqmlZF9bwnFCEu8tQqel4VSuaTMiYJXIG0WY/1rKi7RCW04g1W127w==",
       "requires": {
         "@sinonjs/commons": "^1.3.0",
         "@sinonjs/formatio": "^3.1.0",
@@ -325,7 +325,7 @@
     },
     "bane": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/bane/-/bane-1.1.2.tgz",
+      "resolved": "http://registry.npmjs.org/bane/-/bane-1.1.2.tgz",
       "integrity": "sha1-vGQkjMgjFgx98/I4uH/mLEThB7k="
     },
     "base": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@sinonjs/commons": "^1.3.0",
     "@sinonjs/formatio": "^3.1.0",
-    "@sinonjs/referee": "^3.0.0",
+    "@sinonjs/referee": "^3.1.0",
     "sinon": "^7.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "!lib/**/*.test.js"
   ],
   "devDependencies": {
-    "@sinonjs/formatio": "^3.1.0",
     "eslint": "^4.18.1",
     "eslint-config-sinon": "^1.0.3",
     "eslint-plugin-ie11": "^1.0.0",
@@ -46,6 +45,7 @@
   },
   "dependencies": {
     "@sinonjs/commons": "^1.3.0",
+    "@sinonjs/formatio": "^3.1.0",
     "@sinonjs/referee": "^3.0.0",
     "sinon": "^7.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "!lib/**/*.test.js"
   ],
   "devDependencies": {
-    "@sinonjs/formatio": "^2.0.0",
+    "@sinonjs/formatio": "^3.1.0",
     "eslint": "^4.18.1",
     "eslint-config-sinon": "^1.0.3",
     "eslint-plugin-ie11": "^1.0.0",
@@ -45,8 +45,8 @@
     "rollup-plugin-commonjs": "^8.3.0"
   },
   "dependencies": {
-    "@sinonjs/commons": "^1.2.0",
-    "@sinonjs/referee": "^2.1.1",
-    "sinon": "^6.0.0"
+    "@sinonjs/commons": "^1.3.0",
+    "@sinonjs/referee": "^3.0.0",
+    "sinon": "^7.2.0"
   }
 }


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

This upgrades the two main dependencies to their latest majors. ~~For the build to succeed, [this need to be merged](https://github.com/sinonjs/referee/pull/84), a referee minor released and updated here.~~

#### How to verify - mandatory
1. Check out this branch
2. ~~`npm ln @sinonjs/referee`~~
3. `npm install`
4. `npm t`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).