### PR TITLE
Upgrade eslint

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -17,24 +17,23 @@ rules:
   max-len: [error, {code: 120, ignoreComments: true, ignoreStrings: true}]
 
 overrides:
-    files: '*.test.*'
-    plugins:
-        - mocha
-    env:
-        mocha: true
-    rules:
-        max-nested-callbacks: [error, 6]
-        strict: [error, 'global']
+    - files: '*.test.*'
+      plugins:
+          - mocha
+      env:
+          mocha: true
+      rules:
+          max-nested-callbacks: [error, 6]
+          strict: [error, 'global']
 
-        mocha/handle-done-callback: error
-        mocha/no-exclusive-tests: error
-        mocha/no-global-tests: error
-        mocha/no-hooks-for-single-case: off
-        mocha/no-identical-title: error
-        mocha/no-mocha-arrows: error
-        mocha/no-nested-tests: error
-        mocha/no-return-and-callback: error
-        mocha/no-sibling-hooks: error
-        mocha/no-skipped-tests: error
-        mocha/no-top-level-hooks: error
-
+          mocha/handle-done-callback: error
+          mocha/no-exclusive-tests: error
+          mocha/no-global-tests: error
+          mocha/no-hooks-for-single-case: off
+          mocha/no-identical-title: error
+          mocha/no-mocha-arrows: error
+          mocha/no-nested-tests: error
+          mocha/no-return-and-callback: error
+          mocha/no-sibling-hooks: error
+          mocha/no-skipped-tests: error
+          mocha/no-top-level-hooks: error

--- a/lib/referee-sinon.js
+++ b/lib/referee-sinon.js
@@ -28,11 +28,11 @@ function callsToString(fake) {
     return calls.length > 0 ? "\n" + calls.join("\n") : "";
 }
 
-sinon.expectation.pass = function (assertion) {
+sinon.expectation.pass = function(assertion) {
     referee.emit("pass", assertion);
 };
 
-sinon.expectation.fail = function (message) {
+sinon.expectation.fail = function(message) {
     referee.fail(message);
 };
 
@@ -58,7 +58,9 @@ function verifyFakes() {
         method = arguments[i];
         isNot = (method || "fake") + " is not ";
 
-        if (!method) { this.fail(isNot + "a spy"); }
+        if (!method) {
+            this.fail(isNot + "a spy");
+        }
         if (typeof method.calledWith !== "function") {
             this.fail(isNot + "stubbed");
         }
@@ -68,14 +70,16 @@ function verifyFakes() {
 }
 
 referee.add("callCount", {
-    assert: function (spy, count) {
+    assert: function(spy, count) {
         verifyFakes.call(this, spy);
         return spy.callCount === count;
     },
-    assertMessage: "Expected ${spyObj} to be called exactly ${expectedTimes} times, but was called ${actualTimes}",
-    refuteMessage: "Expected ${spyObj} to not be called exactly ${expectedTimes} times",
+    assertMessage:
+        "Expected ${spyObj} to be called exactly ${expectedTimes} times, but was called ${actualTimes}",
+    refuteMessage:
+        "Expected ${spyObj} to not be called exactly ${expectedTimes} times",
     expectation: "toHaveCallCount",
-    values: function (spyObj, count) {
+    values: function(spyObj, count) {
         return {
             spyObj: spyObj,
             actualTimes: callCount(spyObj),
@@ -85,14 +89,16 @@ referee.add("callCount", {
 });
 
 referee.add("called", {
-    assert: function (spy) {
+    assert: function(spy) {
         verifyFakes.call(this, spy);
         return spy.called;
     },
-    assertMessage: "Expected ${spyObj} to be called at least once but was never called",
-    refuteMessage: "Expected ${spyObj} to not be called but was called ${times}${calls}",
+    assertMessage:
+        "Expected ${spyObj} to be called at least once but was never called",
+    refuteMessage:
+        "Expected ${spyObj} to not be called but was called ${times}${calls}",
     expectation: "toHaveBeenCalled",
-    values: function (spyObj) {
+    values: function(spyObj) {
         return {
             spyObj: spyObj,
             times: callCount(spyObj),
@@ -102,14 +108,15 @@ referee.add("called", {
 });
 
 referee.add("calledWithNew", {
-    assert: function (spy) {
+    assert: function(spy) {
         verifyFakes.call(this, spy);
         return spy.calledWithNew();
     },
-    assertMessage: "Expected ${spyObj} to be called with 'new' at least once but was never called with 'new'",
+    assertMessage:
+        "Expected ${spyObj} to be called with 'new' at least once but was never called with 'new'",
     refuteMessage: "Expected ${spyObj} to not be called with 'new'",
     expectation: "toHaveBeenCalledWithNew",
-    values: function (spyObj) {
+    values: function(spyObj) {
         return {
             spyObj: spyObj
         };
@@ -117,14 +124,14 @@ referee.add("calledWithNew", {
 });
 
 referee.add("alwaysCalledWithNew", {
-    assert: function (spy) {
+    assert: function(spy) {
         verifyFakes.call(this, spy);
         return spy.alwaysCalledWithNew();
     },
     assertMessage: "Expected ${spyObj} to always be called with 'new'",
     refuteMessage: "Expected ${spyObj} to not always be called with 'new'",
     expectation: "toAlwaysHaveBeenCalledWithNew",
-    values: function (spyObj) {
+    values: function(spyObj) {
         return {
             spyObj: spyObj
         };
@@ -132,7 +139,6 @@ referee.add("alwaysCalledWithNew", {
 });
 
 function slice(arr, from, to) {
-
     // don't pass "to" if not defined, because IE8 doesn't like that
     if (to) {
         return [].slice.call(arr, from, to);
@@ -142,32 +148,37 @@ function slice(arr, from, to) {
 }
 
 referee.add("callOrder", {
-    assert: function (spy) {
+    assert: function(spy) {
         var type = Object.prototype.toString.call(spy);
         var isArray = type === "[object Array]";
         var args = isArray ? spy : arguments;
         verifyFakes.apply(this, args);
-        if (calledInOrder(args)) { return true; }
+        if (calledInOrder(args)) {
+            return true;
+        }
 
         this.expected = [].join.call(args, ", ");
         this.actual = orderByFirstCall(slice(args)).join(", ");
         return false;
     },
 
-    assertMessage: "Expected ${expected} to be called in order but were called as ${actual}",
+    assertMessage:
+        "Expected ${expected} to be called in order but were called as ${actual}",
     refuteMessage: "Expected ${expected} not to be called in order"
 });
 
 function addCallCountAssertion(count) {
     referee.add("called" + count, {
-        assert: function (spy) {
+        assert: function(spy) {
             verifyFakes.call(this, spy);
             return spy["called" + count];
         },
-        assertMessage: "Expected ${spyObj} to be called ${expectedTimes} but was called ${times}${calls}",
-        refuteMessage: "Expected ${spyObj} to not be called exactly ${expectedTimes}${calls}",
+        assertMessage:
+            "Expected ${spyObj} to be called ${expectedTimes} but was called ${times}${calls}",
+        refuteMessage:
+            "Expected ${spyObj} to not be called exactly ${expectedTimes}${calls}",
         expectation: "toHaveBeenCalled" + count,
-        values: function (spyObj) {
+        values: function(spyObj) {
             return {
                 spyObj: spyObj,
                 expectedTimes: count.toLowerCase(),
@@ -186,36 +197,42 @@ function valuesWithThis(spyObj, expectedThis) {
     return {
         spyObj: spyObj,
         expectedThis: expectedThis,
-        actualThis: (spyObj.printf ? spyObj.printf("%t") : "")
+        actualThis: spyObj.printf ? spyObj.printf("%t") : ""
     };
 }
 
 referee.add("calledOn", {
-    assert: function (spy, thisObj) {
+    assert: function(spy, thisObj) {
         verifyFakes.call(this, spy);
         return spy.calledOn(thisObj);
     },
-    assertMessage: "Expected ${spyObj} to be called with ${expectedThis} as this but was called on ${actualThis}",
-    refuteMessage: "Expected ${spyObj} not to be called with ${expectedThis} as this",
+    assertMessage:
+        "Expected ${spyObj} to be called with ${expectedThis} as this but was called on ${actualThis}",
+    refuteMessage:
+        "Expected ${spyObj} not to be called with ${expectedThis} as this",
     expectation: "toHaveBeenCalledOn",
     values: valuesWithThis
 });
 
 referee.add("alwaysCalledOn", {
-    assert: function (spy, thisObj) {
+    assert: function(spy, thisObj) {
         verifyFakes.call(this, spy);
         return spy.alwaysCalledOn(thisObj);
     },
-    assertMessage: "Expected ${spyObj} to always be called with ${expectedThis} as this but was called on ${actualThis}",
-    refuteMessage: "Expected ${spyObj} not to always be called with ${expectedThis} as this",
+    assertMessage:
+        "Expected ${spyObj} to always be called with ${expectedThis} as this but was called on ${actualThis}",
+    refuteMessage:
+        "Expected ${spyObj} not to always be called with ${expectedThis} as this",
     expectation: "toHaveAlwaysBeenCalledOn",
     values: valuesWithThis
 });
 
 function formattedArgs(args, i) {
+    var index = i;
     var l, result;
-    for (l = args.length, result = []; i < l; ++i) {
-        push.call(result, format(args[i]));
+
+    for (l = args.length, result = []; index < l; ++index) {
+        push.call(result, format(args[index]));
     }
     return result.join(", ");
 }
@@ -231,90 +248,105 @@ function spyAndCalls(spyObj) {
 }
 
 referee.add("calledWith", {
-    assert: function (spy) {
+    assert: function(spy) {
         verifyFakes.call(this, spy);
         return spy.calledWith.apply(spy, slice(arguments, 1));
     },
-    assertMessage: "Expected ${spyObj} to be called with arguments ${expected}${actual}",
-    refuteMessage: "Expected ${spyObj} not to be called with arguments ${expected}${actual}",
+    assertMessage:
+        "Expected ${spyObj} to be called with arguments ${expected}${actual}",
+    refuteMessage:
+        "Expected ${spyObj} not to be called with arguments ${expected}${actual}",
     expectation: "toHaveBeenCalledWith",
     values: spyAndCalls
 });
 
 referee.add("alwaysCalledWith", {
-    assert: function (spy) {
+    assert: function(spy) {
         verifyFakes.call(this, spy);
         return spy.alwaysCalledWith.apply(spy, slice(arguments, 1));
     },
-    assertMessage: "Expected ${spyObj} to always be called with arguments ${expected}${actual}",
-    refuteMessage: "Expected ${spyObj} not to always be called with arguments ${expected}${actual}",
+    assertMessage:
+        "Expected ${spyObj} to always be called with arguments ${expected}${actual}",
+    refuteMessage:
+        "Expected ${spyObj} not to always be called with arguments ${expected}${actual}",
     expectation: "toHaveAlwaysBeenCalledWith",
     values: spyAndCalls
 });
 
 referee.add("calledOnceWith", {
-    assert: function (spy) {
+    assert: function(spy) {
         verifyFakes.call(this, spy);
-        return spy.calledOnce &&
-            spy.calledWith.apply(spy, slice(arguments, 1));
+        return spy.calledOnce && spy.calledWith.apply(spy, slice(arguments, 1));
     },
-    assertMessage: "Expected ${spyObj} to be called once with arguments ${expected}${actual}",
-    refuteMessage: "Expected ${spyObj} not to be called once with arguments ${expected}${actual}",
+    assertMessage:
+        "Expected ${spyObj} to be called once with arguments ${expected}${actual}",
+    refuteMessage:
+        "Expected ${spyObj} not to be called once with arguments ${expected}${actual}",
     expectation: "toHaveBeenCalledOnceWith",
     values: spyAndCalls
 });
 
 referee.add("calledWithExactly", {
-    assert: function (spy) {
+    assert: function(spy) {
         verifyFakes.call(this, spy);
         return spy.calledWithExactly.apply(spy, slice(arguments, 1));
     },
-    assertMessage: "Expected ${spyObj} to be called with exact arguments ${expected}${actual}",
-    refuteMessage: "Expected ${spyObj} not to be called with exact arguments ${expected}${actual}",
+    assertMessage:
+        "Expected ${spyObj} to be called with exact arguments ${expected}${actual}",
+    refuteMessage:
+        "Expected ${spyObj} not to be called with exact arguments ${expected}${actual}",
     expectation: "toHaveBeenCalledWithExactly",
     values: spyAndCalls
 });
 
 referee.add("alwaysCalledWithExactly", {
-    assert: function (spy) {
+    assert: function(spy) {
         verifyFakes.call(this, spy);
         return spy.alwaysCalledWithExactly.apply(spy, slice(arguments, 1));
     },
-    assertMessage: "Expected ${spyObj} to always be called with exact arguments ${expected}${actual}",
-    refuteMessage: "Expected ${spyObj} not to always be called with exact arguments ${expected}${actual}",
+    assertMessage:
+        "Expected ${spyObj} to always be called with exact arguments ${expected}${actual}",
+    refuteMessage:
+        "Expected ${spyObj} not to always be called with exact arguments ${expected}${actual}",
     expectation: "toHaveAlwaysBeenCalledWithExactly",
     values: spyAndCalls
 });
 
 referee.add("calledOnceWithExactly", {
-    assert: function (spy) {
+    assert: function(spy) {
         verifyFakes.call(this, spy);
         return spy.calledOnceWithExactly.apply(spy, slice(arguments, 1));
     },
-    assertMessage: "Expected ${spyObj} to be called once with exact arguments ${expected}${actual}",
-    refuteMessage: "Expected ${spyObj} not to be once called with exact arguments ${expected}${actual}",
+    assertMessage:
+        "Expected ${spyObj} to be called once with exact arguments ${expected}${actual}",
+    refuteMessage:
+        "Expected ${spyObj} not to be once called with exact arguments ${expected}${actual}",
     expectation: "toHaveBeenCalledOnceWithExactly",
     values: spyAndCalls
 });
 
 referee.add("calledWithMatch", {
-    assert: function (spy) {
+    assert: function(spy) {
         verifyFakes.call(this, spy);
         return spy.calledWithMatch.apply(spy, slice(arguments, 1));
     },
-    assertMessage: "Expected ${spyObj} to be called with matching arguments ${expected}${actual}",
-    refuteMessage: "Expected ${spyObj} not to be called with matching arguments ${expected}${actual}",
+    assertMessage:
+        "Expected ${spyObj} to be called with matching arguments ${expected}${actual}",
+    refuteMessage:
+        "Expected ${spyObj} not to be called with matching arguments ${expected}${actual}",
     expectation: "toHaveBeenCalledWithMatch",
     values: spyAndCalls
 });
 
 referee.add("alwaysCalledWithMatch", {
-    assert: function (spy) {
+    assert: function(spy) {
         verifyFakes.call(this, spy);
         return spy.alwaysCalledWithMatch.apply(spy, slice(arguments, 1));
     },
-    assertMessage: "Expected ${spyObj} to always be called with matching arguments ${expected}${actual}",
-    refuteMessage: "Expected ${spyObj} not to always be called with matching arguments ${expected}${actual}",
+    assertMessage:
+        "Expected ${spyObj} to always be called with matching arguments ${expected}${actual}",
+    refuteMessage:
+        "Expected ${spyObj} not to always be called with matching arguments ${expected}${actual}",
     expectation: "toHaveAlwaysBeenCalledWithMatch",
     values: spyAndCalls
 });
@@ -328,7 +360,7 @@ function spyAndException(spyObj, exception) {
 }
 
 referee.add("threw", {
-    assert: function (spy) {
+    assert: function(spy) {
         verifyFakes.call(this, spy);
         return spy.threw(arguments[1]);
     },
@@ -339,12 +371,13 @@ referee.add("threw", {
 });
 
 referee.add("alwaysThrew", {
-    assert: function (spy) {
+    assert: function(spy) {
         verifyFakes.call(this, spy);
         return spy.alwaysThrew(arguments[1]);
     },
     assertMessage: "Expected ${spyObj} to always throw an exception${actual}",
-    refuteMessage: "Expected ${spyObj} not to always throw an exception${actual}",
+    refuteMessage:
+        "Expected ${spyObj} not to always throw an exception${actual}",
     expectation: "toAlwaysHaveThrown",
     values: spyAndException
 });

--- a/lib/referee-sinon.test.js
+++ b/lib/referee-sinon.test.js
@@ -10,39 +10,47 @@ var expect = referee.expect;
 
 referee = require("./referee-sinon");
 
-
 var formatter = formatio.configure({ quoteStrings: false });
 
-referee.format = function () {
+referee.format = function() {
     return formatter.ascii.apply(formatter, arguments);
 };
 
 function requiresSpy(assertion) {
-    var args = [function () {}, "dummy argument"].concat([].slice.call(arguments, 1));
+    // eslint-disable-next-line no-empty-function
+    var args = [function() {}, "dummy argument"].concat(
+        [].slice.call(arguments, 1)
+    );
 
-    return function () {
-        assert.exception(function () {
-            assert[assertion].apply(assert, args);
-        }, {message: "is not stubbed"});
+    return function() {
+        assert.exception(
+            function() {
+                assert[assertion].apply(assert, args);
+            },
+            { message: "is not stubbed" }
+        );
 
-        assert.exception(function () {
-            refute[assertion].apply(assert, args);
-        }, {message: "is not stubbed"});
+        assert.exception(
+            function() {
+                refute[assertion].apply(assert, args);
+            },
+            { message: "is not stubbed" }
+        );
     };
 }
 
-describe("referee-sinon", function () {
-    afterEach(function () {
+describe("referee-sinon", function() {
+    afterEach(function() {
         sinon.restore();
     });
 
-    describe("sinon", function () {
-        it("exposes sinon", function () {
+    describe("sinon", function() {
+        it("exposes sinon", function() {
             assert.same(referee.sinon, sinon);
         });
     });
 
-    describe("mapping", function () {
+    describe("mapping", function() {
         var DISALLOWED_METHODS = [
             "expose",
             "fail",
@@ -54,30 +62,35 @@ describe("referee-sinon", function () {
             "notCalled",
             "pass"
         ];
-        var sinonMethods = Object.keys(sinon.assert).filter(function (key) {
+        var sinonMethods = Object.keys(sinon.assert).filter(function(key) {
             var isDisallowed = DISALLOWED_METHODS.indexOf(key) !== -1;
             var isFunction = typeof sinon.assert[key] === "function";
 
             return !isDisallowed && isFunction;
         });
 
-        sinonMethods.forEach(function (methodName) {
-            it("should map '" + methodName + "' from sinon.assert", function () {
+        sinonMethods.forEach(function(methodName) {
+            it("should map '" + methodName + "' from sinon.assert", function() {
                 assert.isFunction(referee.assert[methodName]);
                 assert.isFunction(referee.refute[methodName]);
             });
         });
 
-        DISALLOWED_METHODS.forEach(function (methodName) {
-            it("must not map disallowed '" + methodName + "' from sinon.assert", function () {
-                refute.defined(referee.assert[methodName]);
-                refute.defined(referee.refute[methodName]);
-            });
+        DISALLOWED_METHODS.forEach(function(methodName) {
+            it(
+                "must not map disallowed '" +
+                    methodName +
+                    "' from sinon.assert",
+                function() {
+                    refute.defined(referee.assert[methodName]);
+                    refute.defined(referee.refute[methodName]);
+                }
+            );
         });
     });
 
-    describe("assertions", function () {
-        it("formats assert messages through formatio", function () {
+    describe("assertions", function() {
+        it("formats assert messages through formatio", function() {
             sinon.stub(formatio, "ascii").returns("I'm the object");
             var message;
             var spy = sinon.spy();
@@ -92,17 +105,17 @@ describe("referee-sinon", function () {
             assert.match(message, "I'm the object");
         });
 
-        describe("calledWith", function () {
+        describe("calledWith", function() {
             it("fails when not called with spy", requiresSpy("calledWith"));
 
-            it("passes when spy is explicitly passed null", function () {
+            it("passes when spy is explicitly passed null", function() {
                 var spy = sinon.spy();
                 spy(null, "Hey!");
 
                 assert.calledWith(spy, null, "Hey!");
             });
 
-            it("formats message nicely", function () {
+            it("formats message nicely", function() {
                 var spy = sinon.spy();
                 spy(null, 1, 2);
 
@@ -110,14 +123,15 @@ describe("referee-sinon", function () {
                     assert.calledWith(spy, null, 2, 2);
                     throw new Error("Exception expected");
                 } catch (e) {
-                    var message = "[assert.calledWith] Expected function " +
-                            "spy() {} to be called with arguments null, 2, 2" +
-                            "\n    spy(null, 1, 2)";
+                    var message =
+                        "[assert.calledWith] Expected function " +
+                        "spy() {} to be called with arguments null, 2, 2" +
+                        "\n    spy(null, 1, 2)";
                     assert.match(e.message, message);
                 }
             });
 
-            it("doesn't pass undefined to [].slice (IE8 doesn't like that)", function () {
+            it("doesn't pass undefined to [].slice (IE8 doesn't like that)", function() {
                 var spy = sinon.spy();
                 spy("foo");
                 sinon.spy(Array.prototype, "slice");
@@ -126,7 +140,7 @@ describe("referee-sinon", function () {
                 assert.calledWithExactly(Array.prototype.slice, 1);
             });
 
-            it("works with spy calls", function () {
+            it("works with spy calls", function() {
                 var spy = sinon.spy();
                 spy(null, "Hey!");
 
@@ -134,17 +148,20 @@ describe("referee-sinon", function () {
             });
         });
 
-        describe("calledWithExactly", function () {
-            it("fails when not called with spy", requiresSpy("calledWithExactly"));
+        describe("calledWithExactly", function() {
+            it(
+                "fails when not called with spy",
+                requiresSpy("calledWithExactly")
+            );
 
-            it("passes when spy is explicitly passed null", function () {
+            it("passes when spy is explicitly passed null", function() {
                 var spy = sinon.spy();
                 spy(null, "Hey!");
 
                 assert.calledWithExactly(spy, null, "Hey!");
             });
 
-            it("formats message nicely", function () {
+            it("formats message nicely", function() {
                 var spy = sinon.spy();
                 spy(null, 1, 2);
 
@@ -152,14 +169,15 @@ describe("referee-sinon", function () {
                     assert.calledWithExactly(spy, null, 2, 2);
                     throw new Error("Exception expected");
                 } catch (e) {
-                    var message = "[assert.calledWithExactly] Expected " +
-                            "function spy() {} to be called with exact " +
-                            "arguments null, 2, 2\n    spy(null, 1, 2)";
+                    var message =
+                        "[assert.calledWithExactly] Expected " +
+                        "function spy() {} to be called with exact " +
+                        "arguments null, 2, 2\n    spy(null, 1, 2)";
                     assert.match(e.message, message);
                 }
             });
 
-            it("works with spy calls", function () {
+            it("works with spy calls", function() {
                 var spy = sinon.spy();
                 spy(null, "Hey!");
 
@@ -167,10 +185,13 @@ describe("referee-sinon", function () {
             });
         });
 
-        describe("calledWithMatch", function () {
-            it("fails when not called with spy", requiresSpy("calledWithMatch"));
+        describe("calledWithMatch", function() {
+            it(
+                "fails when not called with spy",
+                requiresSpy("calledWithMatch")
+            );
 
-            it("passes when spy is passed matching object", function () {
+            it("passes when spy is passed matching object", function() {
                 var spy = sinon.spy();
                 spy({
                     check: 123,
@@ -180,7 +201,7 @@ describe("referee-sinon", function () {
                 assert.calledWithMatch(spy, { check: 123 });
             });
 
-            it("formats message nicely", function () {
+            it("formats message nicely", function() {
                 var spy = sinon.spy();
                 spy({ check: 123 });
 
@@ -188,14 +209,15 @@ describe("referee-sinon", function () {
                     assert.calledWithMatch(spy, { check: 321 });
                     throw new Error("Exception expected");
                 } catch (e) {
-                    var message = "[assert.calledWithMatch] Expected " +
-                            "function spy() {} to be called with matching " +
-                            "arguments { check: 321 }\n    spy({ check: 123 })";
+                    var message =
+                        "[assert.calledWithMatch] Expected " +
+                        "function spy() {} to be called with matching " +
+                        "arguments { check: 321 }\n    spy({ check: 123 })";
                     assert.match(e.message, message);
                 }
             });
 
-            it("works with spy calls", function () {
+            it("works with spy calls", function() {
                 var spy = sinon.spy();
                 spy({
                     check: 123,
@@ -206,10 +228,13 @@ describe("referee-sinon", function () {
             });
         });
 
-        describe("alwaysCalledWithMatch", function () {
-            it("fails when not called with spy", requiresSpy("alwaysCalledWithMatch"));
+        describe("alwaysCalledWithMatch", function() {
+            it(
+                "fails when not called with spy",
+                requiresSpy("alwaysCalledWithMatch")
+            );
 
-            it("passes when spy is always passed matching object", function () {
+            it("passes when spy is always passed matching object", function() {
                 var spy = sinon.spy();
                 spy({
                     check: 123,
@@ -223,7 +248,7 @@ describe("referee-sinon", function () {
                 assert.alwaysCalledWithMatch(spy, { check: 123 });
             });
 
-            it("formats message nicely", function () {
+            it("formats message nicely", function() {
                 var spy = sinon.spy();
                 spy({ check: 123 });
                 spy({ check: 321 });
@@ -232,9 +257,10 @@ describe("referee-sinon", function () {
                     assert.alwaysCalledWithMatch(spy, { check: 321 });
                     throw new Error("Exception expected");
                 } catch (e) {
-                    var message = "[assert.alwaysCalledWithMatch] Expected " +
-                            "function spy() {} to always be called with " +
-                            "matching arguments { check: 321 }";
+                    var message =
+                        "[assert.alwaysCalledWithMatch] Expected " +
+                        "function spy() {} to always be called with " +
+                        "matching arguments { check: 321 }";
                     assert.match(e.message, message);
                     var lines = e.message.split("\n");
                     assert.equals(lines.length, 3);
@@ -244,32 +270,33 @@ describe("referee-sinon", function () {
             });
         });
 
-        describe("calledOnce", function () {
+        describe("calledOnce", function() {
             it("fails when not called with spy", requiresSpy("calledOnce"));
 
-            it("passes when called once", function () {
+            it("passes when called once", function() {
                 var spy = sinon.spy();
                 spy(null, "Hey");
 
                 assert.calledOnce(spy);
             });
 
-            it("formats message nicely", function () {
+            it("formats message nicely", function() {
                 try {
                     assert.calledOnce(sinon.spy());
                     throw new Error("Exception expected");
                 } catch (e) {
-                    var message = "[assert.calledOnce] Expected function " +
-                            "spy() {} to be called once but was called 0 times";
+                    var message =
+                        "[assert.calledOnce] Expected function " +
+                        "spy() {} to be called once but was called 0 times";
                     assert.match(e.message, message);
                 }
             });
         });
 
-        describe("calledTwice", function () {
+        describe("calledTwice", function() {
             it("fails when not called with spy", requiresSpy("calledTwice"));
 
-            it("passes when called twice", function () {
+            it("passes when called twice", function() {
                 var spy = sinon.spy();
                 spy(null, "Hey");
                 spy(null, "Ho");
@@ -277,7 +304,7 @@ describe("referee-sinon", function () {
                 assert.calledTwice(spy);
             });
 
-            it("formats message nicely", function () {
+            it("formats message nicely", function() {
                 var spy = sinon.spy();
                 spy(null, "Hey");
 
@@ -285,18 +312,19 @@ describe("referee-sinon", function () {
                     assert.calledTwice(spy);
                     throw new Error("Exception expected");
                 } catch (e) {
-                    var message = "[assert.calledTwice] Expected function " +
-                            "spy() {} to be called twice but was called once";
+                    var message =
+                        "[assert.calledTwice] Expected function " +
+                        "spy() {} to be called twice but was called once";
                     assert.match(e.message, message);
                     assert.match(e.message, "spy(null, Hey)");
                 }
             });
         });
 
-        describe("calledThrice", function () {
+        describe("calledThrice", function() {
             it("fails when not called with spy", requiresSpy("calledThrice"));
 
-            it("passes when called thrice", function () {
+            it("passes when called thrice", function() {
                 var spy = sinon.spy();
                 spy(null, "Hey");
                 spy(null, "Ho");
@@ -305,7 +333,7 @@ describe("referee-sinon", function () {
                 assert.calledThrice(spy);
             });
 
-            it("formats message nicely", function () {
+            it("formats message nicely", function() {
                 var spy = sinon.spy();
                 spy(null, "Hey");
                 spy(null, "Ho");
@@ -314,8 +342,9 @@ describe("referee-sinon", function () {
                     assert.calledThrice(spy);
                     throw new Error("Exception expected");
                 } catch (e) {
-                    var message = "[assert.calledThrice] Expected function " +
-                            "spy() {} to be called thrice but was called twice";
+                    var message =
+                        "[assert.calledThrice] Expected function " +
+                        "spy() {} to be called thrice but was called twice";
                     assert.match(e.message, message);
                     assert.match(e.message, "spy(null, Hey)");
                     assert.match(e.message, "spy(null, Ho)");
@@ -323,10 +352,10 @@ describe("referee-sinon", function () {
             });
         });
 
-        describe("callCount", function () {
+        describe("callCount", function() {
             it("fails when not called with spy", requiresSpy("callCount"));
 
-            it("passes as callCount changes", function () {
+            it("passes as callCount changes", function() {
                 var spy = sinon.spy();
 
                 for (var i = 1; i <= 100; i++) {
@@ -335,44 +364,46 @@ describe("referee-sinon", function () {
                 }
             });
 
-            it("formats message nicely", function () {
+            it("formats message nicely", function() {
                 try {
                     assert.callCount(sinon.spy(), 1);
                     throw new Error("Exception expected");
                 } catch (e) {
-                    var message = "[assert.callCount] Expected function spy() {} to be called exactly 1 times, but was called 0 times";
+                    var message =
+                        "[assert.callCount] Expected function spy() {} to be called exactly 1 times, but was called 0 times";
                     assert.match(e.message, message);
                 }
             });
         });
 
-        describe("called", function () {
+        describe("called", function() {
             it("fails when not called with spy", requiresSpy("called"));
 
-            it("passes when called once", function () {
+            it("passes when called once", function() {
                 var spy = sinon.spy();
                 spy(null, "Hey");
 
                 assert.called(spy);
             });
 
-            it("formats message", function () {
+            it("formats message", function() {
                 try {
                     assert.called(sinon.spy());
                     throw new Error("Exception expected");
                 } catch (e) {
-                    var message = "[assert.called] Expected function spy() " +
-                            "{} to be called at least once but was never " +
-                            "called";
+                    var message =
+                        "[assert.called] Expected function spy() " +
+                        "{} to be called at least once but was never " +
+                        "called";
                     assert.equals(e.message, message);
                 }
             });
         });
 
-        describe("calledWithNew", function () {
+        describe("calledWithNew", function() {
             it("fails when not called with spy", requiresSpy("calledWithNew"));
 
-            it("passes when called with new", function () {
+            it("passes when called with new", function() {
                 var spy = sinon.spy();
 
                 // eslint-disable-next-line no-new, new-cap
@@ -381,7 +412,7 @@ describe("referee-sinon", function () {
                 assert.calledWithNew(spy);
             });
 
-            it("formats message", function () {
+            it("formats message", function() {
                 try {
                     var spy = sinon.spy();
                     spy();
@@ -389,12 +420,13 @@ describe("referee-sinon", function () {
                     assert.calledWithNew(spy);
                     throw new Error("Exception expected");
                 } catch (e) {
-                    var message = "[assert.calledWithNew] Expected function spy() {} to be called with 'new' at least once but was never called with 'new'";
+                    var message =
+                        "[assert.calledWithNew] Expected function spy() {} to be called with 'new' at least once but was never called with 'new'";
                     assert.equals(e.message, message);
                 }
             });
 
-            it("works with spy calls", function () {
+            it("works with spy calls", function() {
                 var spy = sinon.spy();
 
                 // eslint-disable-next-line no-new, new-cap
@@ -404,10 +436,13 @@ describe("referee-sinon", function () {
             });
         });
 
-        describe("alwaysCalledWithNew", function () {
-            it("fails when not called with spy", requiresSpy("alwaysCalledWithNew"));
+        describe("alwaysCalledWithNew", function() {
+            it(
+                "fails when not called with spy",
+                requiresSpy("alwaysCalledWithNew")
+            );
 
-            it("passes when always called with new", function () {
+            it("passes when always called with new", function() {
                 var spy = sinon.spy();
 
                 // eslint-disable-next-line no-new, new-cap
@@ -420,7 +455,7 @@ describe("referee-sinon", function () {
                 assert.alwaysCalledWithNew(spy);
             });
 
-            it("formats message", function () {
+            it("formats message", function() {
                 try {
                     var spy = sinon.spy();
                     spy();
@@ -429,16 +464,17 @@ describe("referee-sinon", function () {
                     assert.alwaysCalledWithNew(spy);
                     throw new Error("Exception expected");
                 } catch (e) {
-                    var message = "[assert.alwaysCalledWithNew] Expected function spy() {} to always be called with 'new'";
+                    var message =
+                        "[assert.alwaysCalledWithNew] Expected function spy() {} to always be called with 'new'";
                     assert.equals(e.message, message);
                 }
             });
         });
 
-        describe("callOrder", function () {
+        describe("callOrder", function() {
             it("fails when not called with spy", requiresSpy("callOrder"));
 
-            it("passes when called in order", function () {
+            it("passes when called in order", function() {
                 var spies = [sinon.spy(), sinon.spy()];
                 spies[0]();
                 spies[1]();
@@ -446,7 +482,7 @@ describe("referee-sinon", function () {
                 assert.callOrder(spies[0], spies[1]);
             });
 
-            it("passes when called in order using an array", function () {
+            it("passes when called in order using an array", function() {
                 var spies = [sinon.spy(), sinon.spy()];
                 spies[0]();
                 spies[1]();
@@ -454,7 +490,7 @@ describe("referee-sinon", function () {
                 assert.callOrder(spies);
             });
 
-            it("formats message", function () {
+            it("formats message", function() {
                 var spies = [sinon.spy(), sinon.spy()];
                 spies[1]();
                 spies[0]();
@@ -463,17 +499,18 @@ describe("referee-sinon", function () {
                     assert.callOrder(spies[0], spies[1]);
                     throw new Error("Exception expected");
                 } catch (e) {
-                    var message = "[assert.callOrder] Expected 0, 1 to be " +
-                            "called in order but were called as 1, 0";
+                    var message =
+                        "[assert.callOrder] Expected 0, 1 to be " +
+                        "called in order but were called as 1, 0";
                     assert.equals(e.message, message);
                 }
             });
         });
 
-        describe("calledOn", function () {
+        describe("calledOn", function() {
             it("fails when not called with spy", requiresSpy("calledOn", {}));
 
-            it("passes when called on object", function () {
+            it("passes when called on object", function() {
                 var spy = sinon.spy();
                 var object = { id: 42 };
                 spy.call(object);
@@ -481,7 +518,7 @@ describe("referee-sinon", function () {
                 assert.calledOn(spy, object);
             });
 
-            it("formats message", function () {
+            it("formats message", function() {
                 var spy = sinon.spy();
                 var object = { id: 42 };
                 spy.call(object);
@@ -490,14 +527,15 @@ describe("referee-sinon", function () {
                     assert.calledOn(spy, { id: 12 });
                     throw new Error("Exception expected");
                 } catch (e) {
-                    var message = "[assert.calledOn] Expected function spy() " +
-                            "{} to be called with { id: 12 } as this but was " +
-                            "called on { id: 42 }";
+                    var message =
+                        "[assert.calledOn] Expected function spy() " +
+                        "{} to be called with { id: 12 } as this but was " +
+                        "called on { id: 42 }";
                     assert.equals(e.message, message);
                 }
             });
 
-            it("works with spy calls", function () {
+            it("works with spy calls", function() {
                 var spy = sinon.spy();
                 var object = { id: 42 };
                 spy.call(object);
@@ -506,10 +544,13 @@ describe("referee-sinon", function () {
             });
         });
 
-        describe("alwaysCalledOn", function () {
-            it("fails when not called with spy", requiresSpy("alwaysCalledOn", {}));
+        describe("alwaysCalledOn", function() {
+            it(
+                "fails when not called with spy",
+                requiresSpy("alwaysCalledOn", {})
+            );
 
-            it("passes when called on object", function () {
+            it("passes when called on object", function() {
                 var spy = sinon.spy();
                 var object = { id: 42 };
                 spy.call(object);
@@ -517,7 +558,7 @@ describe("referee-sinon", function () {
                 assert.alwaysCalledOn(spy, object);
             });
 
-            it("formats message", function () {
+            it("formats message", function() {
                 var spy = sinon.spy();
                 var object = { id: 42 };
                 spy.call(object);
@@ -526,18 +567,22 @@ describe("referee-sinon", function () {
                     assert.alwaysCalledOn(spy, { id: 12 });
                     throw new Error("Exception expected");
                 } catch (e) {
-                    var message = "[assert.alwaysCalledOn] Expected function " +
-                            "spy() {} to always be called with { id: 12 } as " +
-                            "this but was called on { id: 42 }";
+                    var message =
+                        "[assert.alwaysCalledOn] Expected function " +
+                        "spy() {} to always be called with { id: 12 } as " +
+                        "this but was called on { id: 42 }";
                     assert.equals(e.message, message);
                 }
             });
         });
 
-        describe("alwaysCalledWith", function () {
-            it("fails when not called with spy", requiresSpy("alwaysCalledWith"));
+        describe("alwaysCalledWith", function() {
+            it(
+                "fails when not called with spy",
+                requiresSpy("alwaysCalledWith")
+            );
 
-            it("passes when always called with same value", function () {
+            it("passes when always called with same value", function() {
                 var spy = sinon.spy();
                 spy(42);
                 spy(42);
@@ -545,7 +590,7 @@ describe("referee-sinon", function () {
                 assert.alwaysCalledWith(spy, 42);
             });
 
-            it("formats message", function () {
+            it("formats message", function() {
                 var spy = sinon.spy();
                 spy(42);
 
@@ -553,25 +598,29 @@ describe("referee-sinon", function () {
                     assert.alwaysCalledWith(spy, 12);
                     throw new Error("Exception expected");
                 } catch (e) {
-                    var message = "[assert.alwaysCalledWith] Expected " +
-                            "function spy() {} to always be called with " +
-                            "arguments 12\n    spy(42)";
+                    var message =
+                        "[assert.alwaysCalledWith] Expected " +
+                        "function spy() {} to always be called with " +
+                        "arguments 12\n    spy(42)";
                     assert.match(e.message, message);
                 }
             });
         });
 
-        describe("alwaysCalledWithExactly", function () {
-            it("fails when not called with spy", requiresSpy("alwaysCalledWithExactly"));
+        describe("alwaysCalledWithExactly", function() {
+            it(
+                "fails when not called with spy",
+                requiresSpy("alwaysCalledWithExactly")
+            );
 
-            it("fails when spy is explicitly passed null", function () {
+            it("fails when spy is explicitly passed null", function() {
                 var spy = sinon.spy();
                 spy(null, "Hey");
 
                 refute.alwaysCalledWithExactly(spy, null, "Hey!");
             });
 
-            it("formats message nicely", function () {
+            it("formats message nicely", function() {
                 var spy = sinon.spy();
                 spy(null, 1, 2);
 
@@ -579,105 +628,107 @@ describe("referee-sinon", function () {
                     assert.alwaysCalledWithExactly(spy, null, 2, 2);
                     throw new Error("Exception expected");
                 } catch (e) {
-                    var message = "[assert.alwaysCalledWithExactly] Expected " +
-                            "function spy() {} to always be called with " +
-                            "exact arguments null, 2, 2\n    spy(null, 1, 2)";
+                    var message =
+                        "[assert.alwaysCalledWithExactly] Expected " +
+                        "function spy() {} to always be called with " +
+                        "exact arguments null, 2, 2\n    spy(null, 1, 2)";
                     assert.match(e.message, message);
                 }
             });
         });
 
-        describe("threw", function () {
+        describe("threw", function() {
             it("fails when not called with spy", requiresSpy("threw"));
 
-            it("passes when spy threw", function () {
+            it("passes when spy threw", function() {
                 var spy = sinon.stub().throws();
                 try {
                     spy();
-                // eslint-disable-next-line no-empty
+                    // eslint-disable-next-line no-empty
                 } catch (e) {}
                 assert.threw(spy);
             });
 
-            it("formats message nicely", function () {
+            it("formats message nicely", function() {
                 var spy = sinon.spy();
 
                 try {
                     assert.threw(spy);
                     throw new Error("Exception expected");
                 } catch (e) {
-                    var message = "[assert.threw] Expected function spy() " +
-                            "{} to throw an exception";
+                    var message =
+                        "[assert.threw] Expected function spy() " +
+                        "{} to throw an exception";
                     assert.match(e.message, message);
                 }
             });
 
-            it("works with spy calls", function () {
+            it("works with spy calls", function() {
                 var spy = sinon.stub().throws();
                 try {
                     spy();
-                // eslint-disable-next-line no-empty
+                    // eslint-disable-next-line no-empty
                 } catch (e) {}
                 assert.threw(spy.firstCall);
             });
         });
 
-        describe("alwaysThrew", function () {
+        describe("alwaysThrew", function() {
             it("fails when not called with spy", requiresSpy("alwaysThrew"));
 
-            it("passes when spy always threw", function () {
+            it("passes when spy always threw", function() {
                 var spy = sinon.stub().throws();
                 try {
                     spy();
-                // eslint-disable-next-line no-empty
+                    // eslint-disable-next-line no-empty
                 } catch (e) {}
                 assert.alwaysThrew(spy);
             });
 
-            it("formats message nicely", function () {
+            it("formats message nicely", function() {
                 var spy = sinon.spy();
 
                 try {
                     assert.alwaysThrew(spy);
                     throw new Error("Exception expected");
                 } catch (e) {
-                    var message = "[assert.alwaysThrew] Expected function " +
-                            "spy() {} to always throw an exception";
+                    var message =
+                        "[assert.alwaysThrew] Expected function " +
+                        "spy() {} to always throw an exception";
                     assert.match(e.message, message);
                 }
             });
         });
 
-        describe("calledOnceWith", function () {
+        describe("calledOnceWith", function() {
             it("fails when not called with spy", requiresSpy("calledOnceWith"));
 
-
-            it("passes when called once with object", function () {
+            it("passes when called once with object", function() {
                 var spy = sinon.spy();
                 spy(42);
 
                 assert.calledOnceWith(spy, 42);
             });
 
-            it("fails when not called", function () {
+            it("fails when not called", function() {
                 var spy = sinon.spy();
                 refute.calledOnceWith(spy, 42);
             });
 
-            it("fails when not called with argument", function () {
+            it("fails when not called with argument", function() {
                 var spy = sinon.spy();
                 spy();
                 refute.calledOnceWith(spy, 42);
             });
 
-            it("fails when called twice", function () {
+            it("fails when called twice", function() {
                 var spy = sinon.spy();
                 spy(42);
                 spy(42);
                 refute.calledOnceWith(spy, 42);
             });
 
-            it("formats message", function () {
+            it("formats message", function() {
                 var spy = sinon.spy();
                 spy(42);
 
@@ -685,17 +736,18 @@ describe("referee-sinon", function () {
                     assert.calledOnceWith(spy, 12);
                     throw new Error("Exception expected");
                 } catch (e) {
-                    var message = "[assert.calledOnceWith] Expected function " +
-                            "spy() {} to be called once with arguments 12\n" +
-                            "    spy(42)";
+                    var message =
+                        "[assert.calledOnceWith] Expected function " +
+                        "spy() {} to be called once with arguments 12\n" +
+                        "    spy(42)";
                     assert.match(e.message, message);
                 }
             });
         });
     });
 
-    describe("expectations", function () {
-        it("toHaveBeenCalledWithMatch", function () {
+    describe("expectations", function() {
+        it("toHaveBeenCalledWithMatch", function() {
             var stub = sinon.stub(assert, "calledWithMatch");
 
             expect().toHaveBeenCalledWithMatch();
@@ -703,7 +755,7 @@ describe("referee-sinon", function () {
             assert.calledOnce(stub);
         });
 
-        it("toHaveAlwaysBeenCalledWithMatch", function () {
+        it("toHaveAlwaysBeenCalledWithMatch", function() {
             var stub = sinon.stub(assert, "alwaysCalledWithMatch");
 
             expect().toHaveAlwaysBeenCalledWithMatch();
@@ -712,21 +764,21 @@ describe("referee-sinon", function () {
         });
     });
 
-    describe("sinon assert failures", function () {
-        it("delegates to referee.assert.fail", function () {
+    describe("sinon assert failures", function() {
+        it("delegates to referee.assert.fail", function() {
             sinon.stub(referee, "fail");
 
             try {
                 assert.calledOnce(sinon.spy());
-            // eslint-disable-next-line no-empty
+                // eslint-disable-next-line no-empty
             } catch (e) {}
 
             assert(referee.fail.calledOnce);
         });
     });
 
-    describe("sinon assert pass", function () {
-        it("emits pass event through referee.assert", function () {
+    describe("sinon assert pass", function() {
+        it("emits pass event through referee.assert", function() {
             var pass = sinon.spy();
             referee.on("pass", pass);
 
@@ -739,21 +791,21 @@ describe("referee-sinon", function () {
         });
     });
 
-    describe("sinon mock expectation failures", function () {
-        it("delegates to referee.assert.fail", function () {
+    describe("sinon mock expectation failures", function() {
+        it("delegates to referee.assert.fail", function() {
             sinon.stub(referee, "fail");
 
             try {
                 sinon.mock().never()();
-            // eslint-disable-next-line no-empty
+                // eslint-disable-next-line no-empty
             } catch (e) {}
 
             assert(referee.fail.calledOnce);
         });
     });
 
-    describe("sinon mock expectation pass", function () {
-        it("emits pass event through referee.assert", function () {
+    describe("sinon mock expectation pass", function() {
+        it("emits pass event through referee.assert", function() {
             var pass = sinon.spy();
             referee.on("pass", pass);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -281,27 +281,16 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-      "dev": true,
-      "requires": {
-        "acorn": "^3.0.4"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        }
-      }
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
+      "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
+      "dev": true
     },
     "aggregate-error": {
       "version": "3.0.0",
@@ -314,22 +303,16 @@
       }
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
+        "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
-    },
-    "ajv-keywords": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
-      "dev": true
     },
     "ansi-colors": {
       "version": "3.2.3",
@@ -390,67 +373,11 @@
       "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
       "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
     },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "^1.0.1"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -477,12 +404,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true
-    },
-    "buffer-from": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
       "dev": true
     },
     "builtin-modules": {
@@ -520,19 +441,10 @@
         }
       }
     },
-    "caller-path": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
-      "requires": {
-        "callsites": "^0.2.0"
-      }
-    },
     "callsites": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
     "camelcase": {
@@ -564,21 +476,15 @@
       }
     },
     "chardet": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-      "dev": true
-    },
-    "circular-json": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "clean-stack": {
@@ -708,12 +614,6 @@
         }
       }
     },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
-    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -753,18 +653,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
     "convert-source-map": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
@@ -773,12 +661,6 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
     },
     "cosmiconfig": {
       "version": "5.2.1",
@@ -814,12 +696,14 @@
       }
     },
     "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
@@ -831,12 +715,12 @@
       "dev": true
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "decamelize": {
@@ -876,21 +760,6 @@
         "object-keys": "^1.0.8"
       }
     },
-    "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "requires": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
-      }
-    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -914,9 +783,9 @@
       }
     },
     "doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
@@ -989,55 +858,116 @@
       "dev": true
     },
     "eslint": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
-      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.5.1.tgz",
+      "integrity": "sha512-32h99BoLYStT1iq1v2P9uwpyznQ4M2jRiFB6acitKz52Gqn+vPaMDUTB1bYi1WN4Nquj2w+t+bimYUG83DC55A==",
       "dev": true,
       "requires": {
-        "ajv": "^5.3.0",
-        "babel-code-frame": "^6.22.0",
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
         "chalk": "^2.1.0",
-        "concat-stream": "^1.6.0",
-        "cross-spawn": "^5.1.0",
-        "debug": "^3.1.0",
-        "doctrine": "^2.1.0",
-        "eslint-scope": "^3.7.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^3.5.4",
-        "esquery": "^1.0.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.2",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.1",
+        "esquery": "^1.0.1",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
+        "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
-        "globals": "^11.0.1",
-        "ignore": "^3.3.3",
+        "glob-parent": "^5.0.0",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^3.0.6",
-        "is-resolvable": "^1.0.0",
-        "js-yaml": "^3.9.1",
+        "inquirer": "^6.4.1",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.2",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
         "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
-        "pluralize": "^7.0.0",
         "progress": "^2.0.0",
-        "regexpp": "^1.0.1",
-        "require-uncached": "^1.0.3",
-        "semver": "^5.3.0",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "~2.0.1",
-        "table": "4.0.2",
-        "text-table": "~0.2.0"
+        "regexpp": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        },
+        "import-fresh": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+          "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+          "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.3.0.tgz",
+      "integrity": "sha512-EWaGjlDAZRzVFveh2Jsglcere2KK5CJBhkNSa1xs3KfMUGdRiT7lG089eqPdvlzWHpAqaekubOsOMu8W8Yk71A==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+          "dev": true
+        }
       }
     },
     "eslint-config-sinon": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-config-sinon/-/eslint-config-sinon-1.0.3.tgz",
-      "integrity": "sha1-6vcFIqGL8yUKuQMcfEPw2LD0Daw=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-sinon/-/eslint-config-sinon-3.0.1.tgz",
+      "integrity": "sha512-hHEHWZjqxhqKN5N3r6542YHU5OLtSOJDWYeAfbMLzqn/QWMNROjMaZzm5GlmOfgFFxviQ5wsOz3lxKTrfR8KwQ==",
       "dev": true
     },
     "eslint-plugin-ie11": {
@@ -1058,30 +988,49 @@
         "ramda": "^0.26.1"
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.1.tgz",
+      "integrity": "sha512-A+TZuHZ0KU0cnn56/9mfR7/KjUJ9QNVXUhwvRFSR7PGPe0zQR6PTkmyqg1AtUUEOzTqeRsUwyKFh0oVZKVCrtA==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
     "eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+      "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
       "dev": true,
       "requires": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
       }
     },
+    "eslint-utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
     "eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
       "dev": true
     },
     "espree": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
+      "integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
       "dev": true,
       "requires": {
-        "acorn": "^5.5.0",
-        "acorn-jsx": "^3.0.0"
+        "acorn": "^7.0.0",
+        "acorn-jsx": "^5.0.2",
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "esprima": {
@@ -1109,9 +1058,9 @@
       }
     },
     "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
     "estree-walker": {
@@ -1174,20 +1123,26 @@
       }
     },
     "external-editor": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
       "dev": true,
       "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
       }
     },
     "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "fast-glob": {
@@ -1246,13 +1201,12 @@
       }
     },
     "file-entry-cache": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "^2.0.1"
       }
     },
     "find-cache-dir": {
@@ -1293,16 +1247,46 @@
       }
     },
     "flat-cache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "del": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "write": "^0.2.1"
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
+    },
+    "flatted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+      "dev": true
     },
     "foreach": {
       "version": "2.0.5",
@@ -1391,25 +1375,20 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-parent": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
     "globals": {
       "version": "11.5.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.5.0.tgz",
       "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
       "dev": true
-    },
-    "globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
-      "requires": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      }
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -1680,18 +1659,18 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-      "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": "^2.1.0"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ignore": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
-      "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
     "import-fresh": {
@@ -1750,25 +1729,67 @@
       "dev": true
     },
     "inquirer": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.0",
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
         "cli-cursor": "^2.1.0",
         "cli-width": "^2.0.0",
-        "external-editor": "^2.0.4",
+        "external-editor": "^3.0.3",
         "figures": "^2.0.0",
-        "lodash": "^4.3.0",
+        "lodash": "^4.17.12",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
-        "rx-lite": "^4.0.8",
-        "rx-lite-aggregates": "^4.0.8",
+        "rxjs": "^6.4.0",
         "string-width": "^2.1.0",
-        "strip-ansi": "^4.0.0",
+        "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "is-arrayish": {
@@ -1849,30 +1870,6 @@
         "symbol-observable": "^1.1.0"
       }
     },
-    "is-path-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-      "dev": true
-    },
-    "is-path-in-cwd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "^1.0.0"
-      }
-    },
-    "is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "^1.0.1"
-      }
-    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
@@ -1892,12 +1889,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
-      "dev": true
-    },
-    "is-resolvable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
     "is-stream": {
@@ -2051,12 +2042,6 @@
         "handlebars": "^4.1.2"
       }
     },
-    "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
-    },
     "js-yaml": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
@@ -2080,9 +2065,9 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
     "json-stable-stringify-without-jsonify": {
@@ -2707,9 +2692,9 @@
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
     "mute-stream": {
@@ -3072,6 +3057,15 @@
         }
       }
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -3092,12 +3086,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "path-is-inside": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-key": {
@@ -3149,27 +3137,6 @@
       "integrity": "sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg==",
       "dev": true
     },
-    "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "^2.0.0"
-      }
-    },
     "pkg-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
@@ -3188,28 +3155,31 @@
         "semver-compare": "^1.0.0"
       }
     },
-    "pluralize": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-      "dev": true
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
-    "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+    "prettier": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
       "dev": true
     },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
+    },
     "progress": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "pseudomap": {
@@ -3227,6 +3197,12 @@
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
       }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "ramda": {
       "version": "0.26.1",
@@ -3255,33 +3231,10 @@
         "read-pkg": "^3.0.0"
       }
     },
-    "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "dev": true,
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        }
-      }
-    },
     "regexpp": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
-      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
     },
     "release-zalgo": {
@@ -3305,16 +3258,6 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
-    "require-uncached": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
-      }
-    },
     "requireindex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
@@ -3331,9 +3274,9 @@
       }
     },
     "resolve-from": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
     "restore-cursor": {
@@ -3421,21 +3364,6 @@
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
       "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
       "dev": true
-    },
-    "rx-lite": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
-    },
-    "rx-lite-aggregates": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-      "dev": true,
-      "requires": {
-        "rx-lite": "*"
-      }
     },
     "rxjs": {
       "version": "6.5.3",
@@ -3552,12 +3480,25 @@
       "dev": true
     },
     "slice-ansi": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
       "dev": true,
       "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        }
       }
     },
     "source-map": {
@@ -3651,15 +3592,6 @@
         "function-bind": "^1.0.2"
       }
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "stringify-object": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
@@ -3728,17 +3660,43 @@
       "dev": true
     },
     "table": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
       "dev": true,
       "requires": {
-        "ajv": "^5.2.3",
-        "ajv-keywords": "^2.1.0",
-        "chalk": "^2.1.0",
-        "lodash": "^4.17.4",
-        "slice-ansi": "1.0.0",
-        "string-width": "^2.1.1"
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "test-exclude": {
@@ -3839,12 +3797,6 @@
       "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
       "dev": true
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
-    },
     "uglify-js": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
@@ -3865,16 +3817,25 @@
         }
       }
     },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
     },
     "uuid": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
       "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "dev": true
+    },
+    "v8-compile-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -3934,9 +3895,9 @@
       "dev": true
     },
     "write": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"

--- a/package.json
+++ b/package.json
@@ -30,16 +30,19 @@
     "!lib/**/*.test.js"
   ],
   "devDependencies": {
-    "eslint": "^4.18.1",
-    "eslint-config-sinon": "^1.0.3",
+    "eslint": "^6.5.1",
+    "eslint-config-prettier": "^6.3.0",
+    "eslint-config-sinon": "^3.0.1",
     "eslint-plugin-ie11": "^1.0.0",
     "eslint-plugin-mocha": "^6.1.1",
+    "eslint-plugin-prettier": "^3.1.1",
     "husky": "^3.0.8",
     "lint-staged": "^9.4.0",
     "mkdirp": "^0.5.1",
     "mocha": "^6.2.1",
     "npm-run-all": "^4.1.2",
     "nyc": "^14.1.1",
+    "prettier": "^1.18.2",
     "rollup": "^1.23.1",
     "rollup-plugin-commonjs": "^9.3.4"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,5 @@ module.exports = {
     entry: "lib/referee-sinon.js",
     format: "umd",
     moduleName: "refereeSinon",
-    plugins: [
-        commonjs({sourceMap: false})
-    ]
+    plugins: [commonjs({ sourceMap: false })]
 };


### PR DESCRIPTION
This PR replaces https://github.com/sinonjs/referee-sinon/pull/39, and upgrades `eslint`, `eslint-config-sinon` and adds missing libraries and configs ... and fixes the new lint violations.

#### How to verify - mandatory
1. Observe that the linting passes!
