### PR TITLE
Remove IE8 workaround

### DIFF
--- a/lib/referee-sinon.js
+++ b/lib/referee-sinon.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var slice = require("@sinonjs/commons").prototypes.array.slice;
 var calledInOrder = require("@sinonjs/commons").calledInOrder;
 var orderByFirstCall = require("@sinonjs/commons").orderByFirstCall;
 var referee = require("@sinonjs/referee");
@@ -143,15 +144,6 @@ referee.add("alwaysCalledWithNew", {
         };
     }
 });
-
-function slice(arr, from, to) {
-    // don't pass "to" if not defined, because IE8 doesn't like that
-    if (to) {
-        return [].slice.call(arr, from, to);
-    }
-
-    return [].slice.call(arr, from);
-}
 
 referee.add("callOrder", {
     assert: function(spy) {

--- a/lib/referee-sinon.test.js
+++ b/lib/referee-sinon.test.js
@@ -131,15 +131,6 @@ describe("referee-sinon", function() {
                 }
             });
 
-            it("doesn't pass undefined to [].slice (IE8 doesn't like that)", function() {
-                var spy = sinon.spy();
-                spy("foo");
-                sinon.spy(Array.prototype, "slice");
-
-                assert.calledWith(spy, "foo");
-                assert.calledWithExactly(Array.prototype.slice, 1);
-            });
-
             it("works with spy calls", function() {
                 var spy = sinon.spy();
                 spy(null, "Hey!");


### PR DESCRIPTION
The code works fine in IE11, which is the only version of IE we care to support.

Removing this code helps move us towards 100% test coverage.

Setting `semver:major` because it will break things for IE8 users.

#### How to verify - mandatory
1. Check out this branch
2. `npm ci`
3. `npm run test-cloud`
