### PR TITLE
Add tests for calledOnceWithExactly

### DIFF
--- a/lib/referee-sinon.test.js
+++ b/lib/referee-sinon.test.js
@@ -628,6 +628,49 @@ describe("referee-sinon", function() {
             });
         });
 
+        describe("calledOnceWithExactly", function() {
+            it(
+                "fails when not called with spy",
+                requiresSpy("calledOnceWithExactly")
+            );
+
+            it("fails when spy is explicitly passed null", function() {
+                var spy = sinon.spy();
+                spy(null, "Hey");
+
+                refute.calledOnceWithExactly(spy, null, "Hey!");
+            });
+
+            context(
+                "when called more than once with same arguments",
+                function() {
+                    it("fails", function() {
+                        var spy = sinon.spy();
+                        spy("hello", "Hey");
+                        spy("hello", "Hey");
+
+                        refute.calledOnceWithExactly(spy, "hello", "Hey");
+                    });
+                }
+            );
+
+            it("formats message nicely", function() {
+                var spy = sinon.spy();
+                spy(null, 1, 2);
+
+                try {
+                    assert.calledOnceWithExactly(spy, null, 2, 2);
+                    throw new Error("Exception expected");
+                } catch (e) {
+                    var message =
+                        "[assert.calledOnceWithExactly] Expected " +
+                        "function spy() {} to be called once with exact arguments " +
+                        "null, 2, 2\n    spy(null, 1, 2)";
+                    assert.match(e.message, message);
+                }
+            });
+        });
+
         describe("threw", function() {
             it("fails when not called with spy", requiresSpy("threw"));
 


### PR DESCRIPTION
This PR adds tests for ,which helps increase test coverage.

#### Before

```
------------------|----------|----------|----------|----------|-------------------|
File              |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
------------------|----------|----------|----------|----------|-------------------|
All files         |    97.35 |    92.31 |    97.14 |    97.35 |                   |
 referee-sinon.js |    97.35 |    92.31 |    97.14 |    97.35 |        69,315,316 |
------------------|----------|----------|----------|----------|-------------------|
```

#### After

```
------------------|----------|----------|----------|----------|-------------------|
File              |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
------------------|----------|----------|----------|----------|-------------------|
All files         |    99.12 |    92.31 |      100 |    99.12 |                   |
 referee-sinon.js |    99.12 |    92.31 |      100 |    99.12 |                69 |
------------------|----------|----------|----------|----------|-------------------|

```