### PR TITLE
Drop Node 8 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,15 +48,6 @@ jobs:
           name: lint
           command: npm run lint
 
-  node-8:
-    docker:
-      - image: circleci/node:8
-    steps:
-      - *attach-step
-      - run:
-          name: Test
-          command: npm test
-
   node-10:
     docker:
       - image: circleci/node:10
@@ -78,6 +69,26 @@ jobs:
           name: Upload coverage report
           command: bash <(curl -s https://codecov.io/bash) -F unit -s coverage/lcov.info
 
+  node-13:
+    docker:
+      - image: circleci/node:13
+    steps:
+      - *attach-step
+      - run:
+          name: Test
+          command: npm test
+
+
+  saucelabs:
+    docker:
+      - image: circleci/node:12
+    steps:
+      - *attach-step
+      - run:
+          name: Test in browsers (Sauce Labs)
+          command: npm run test-cloud
+
+
 workflows:
   version: 2
   workflow:
@@ -86,12 +97,21 @@ workflows:
       - lint:
           requires:
             - install-dependencies
-      - node-8:
-          requires:
-            - install-dependencies
       - node-10:
           requires:
             - install-dependencies
       - node-12:
           requires:
             - install-dependencies
+      - node-13:
+          requires:
+            - install-dependencies
+      - saucelabs:
+          requires:
+            - lint
+            - node-10
+            - node-12
+            - node-13
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
As can be seen at https://github.com/nodejs/Release, Node 8 reached
"end" of life on 2019-12-31, and is no longer actively supported.

We will stop testing in Node 8 and start testing in Node 13, which will
become the next LTS release from April 2020.

#### How to verify

1. Observe that we're no longer testing in Node 8
2. Observe that we're no testing in Node 13
