### PR TITLE
Referee v6

### DIFF
--- a/lib/referee-sinon.js
+++ b/lib/referee-sinon.js
@@ -11,12 +11,12 @@ var timesInWords = [null, "once", "twice", "thrice"];
 var push = Array.prototype.push;
 
 function callCount(fake) {
-    var count = fake.callCount;
+    var count = fake ? fake.callCount : 0;
     return timesInWords[count] || (count || 0) + " times";
 }
 
 function callsToString(fake) {
-    if (typeof fake.getCalls !== "function") {
+    if (!fake || typeof fake.getCalls !== "function") {
         return "";
     }
 
@@ -195,7 +195,7 @@ function valuesWithThis(spyObj, expectedThis) {
     return {
         spyObj: spyObj,
         expectedThis: expectedThis,
-        actualThis: spyObj.printf ? spyObj.printf("%t") : ""
+        actualThis: spyObj && spyObj.printf ? spyObj.printf("%t") : ""
     };
 }
 
@@ -237,7 +237,7 @@ function formattedArgs(args, i) {
 
 function spyAndCalls(spyObj) {
     var expected = formattedArgs(arguments, 1);
-    var actual = spyObj.printf ? spyObj.printf("%C") : "";
+    var actual = spyObj && spyObj.printf ? spyObj.printf("%C") : "";
     return {
         spyObj: spyObj,
         actual: actual,
@@ -352,7 +352,7 @@ referee.add("alwaysCalledWithMatch", {
 function spyAndException(spyObj, exception) {
     return {
         spyObj: spyObj,
-        actual: spyObj.printf ? spyObj.printf("%C") : "",
+        actual: spyObj && spyObj.printf ? spyObj.printf("%C") : "",
         exception: exception // note: not actually used
     };
 }

--- a/lib/referee-sinon.test.js
+++ b/lib/referee-sinon.test.js
@@ -23,7 +23,7 @@ function requiresSpy(assertion) {
     );
 
     assert.exception(function() {
-        var argsWithoutFunction = [undefined];
+        var argsWithoutFunction = [undefined, undefined];
         assert[assertion].apply(assert, argsWithoutFunction);
     }, /is not a spy/);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -239,15 +239,14 @@
       }
     },
     "@sinonjs/referee": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-5.0.1.tgz",
-      "integrity": "sha512-cpslycKLxnp7fMmYkbmHsb401ifFJgrHUTvsrA0lRXaM5Yt7VkH3a/w3EB+U2fzheo88cRR7tWqS4zO+iL2j0Q==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-6.0.0.tgz",
+      "integrity": "sha512-mML61SwoE3hURaaGqXcbMR1UcyW8nil5l7a+LU7veevTlCoUML2sdZ1vqY5PW1SDTR5yaldOq7bWeZbIYvP58A==",
       "requires": {
         "@sinonjs/commons": "^1.4.0",
         "@sinonjs/formatio": "^5.0.1",
         "@sinonjs/samsam": "^5.0.2",
         "array-from": "2.1.1",
-        "bane": "^1.x",
         "lodash.includes": "^4.3.0",
         "lodash.isarguments": "^3.1.0",
         "object-assign": "^4.1.1"
@@ -590,11 +589,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "bane": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/bane/-/bane-1.1.2.tgz",
-      "integrity": "sha1-vGQkjMgjFgx98/I4uH/mLEThB7k="
     },
     "base": {
       "version": "0.11.2",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@sinonjs/commons": "^1.7.0",
     "@sinonjs/formatio": "^5.0.1",
-    "@sinonjs/referee": "^5.0.0",
+    "@sinonjs/referee": "^6.0.0",
     "sinon": "^9.0.0"
   }
 }


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Upgrade referee to v6 and fix issues that where brought to the light by https://github.com/sinonjs/referee/pull/146.

Are we making this a major release in this project as well, since referee is re-exposed?
#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
