### PR TITLE
Replace formatio with util inspect

### DIFF
--- a/lib/referee-sinon.js
+++ b/lib/referee-sinon.js
@@ -1,14 +1,13 @@
 "use strict";
 
+var inspect = require("util").inspect;
 var slice = require("@sinonjs/commons").prototypes.array.slice;
 var calledInOrder = require("@sinonjs/commons").calledInOrder;
 var orderByFirstCall = require("@sinonjs/commons").orderByFirstCall;
 var referee = require("@sinonjs/referee");
-var formatio = require("@sinonjs/formatio");
 var sinon = require("sinon");
 
 var timesInWords = [null, "once", "twice", "thrice"];
-var push = Array.prototype.push;
 
 function callCount(fake) {
     var count = fake ? fake.callCount : 0;
@@ -43,19 +42,13 @@ sinon.expectation.fail = function(message) {
     referee.fail(message);
 };
 
-// Lazy bind the format method to referee's. This way, Sinon will
-// always format objects like referee does, even if referee is
-// configured after referee-sinon is loaded
-var formatter = formatio.configure({
-    quoteStrings: false,
-    limitChildrenCount: 250
-});
-
-function format() {
-    return formatter.ascii.apply(formatter, arguments);
+function format(object) {
+    if (object instanceof Error) {
+        return object.name;
+    }
+    return inspect(object);
 }
 
-referee.setFormatter(format);
 sinon.setFormatter(format);
 
 function verifyFakes() {
@@ -82,7 +75,7 @@ referee.add("callCount", {
         return spy.callCount === count;
     },
     assertMessage:
-        "Expected ${spyObj} to be called exactly ${expectedTimes} times, but was called ${actualTimes}",
+        "Expected ${spyObj} to be called exactly ${expectedTimes} times, but was called ${!actualTimes}",
     refuteMessage:
         "Expected ${spyObj} to not be called exactly ${expectedTimes} times",
     expectation: "toHaveCallCount",
@@ -155,14 +148,13 @@ referee.add("callOrder", {
             return true;
         }
 
-        this.expected = [].join.call(args, ", ");
+        this.expected = slice(args).join(", ");
         this.actual = orderByFirstCall(slice(args)).join(", ");
         return false;
     },
-
     assertMessage:
-        "Expected ${expected} to be called in order but were called as ${actual}",
-    refuteMessage: "Expected ${expected} not to be called in order"
+        "Expected ${!expected} to be called in order but were called as ${!actual}",
+    refuteMessage: "Expected ${!expected} not to be called in order"
 });
 
 function addCallCountAssertion(count) {
@@ -172,9 +164,9 @@ function addCallCountAssertion(count) {
             return spy["called" + count];
         },
         assertMessage:
-            "Expected ${spyObj} to be called ${expectedTimes} but was called ${times}${calls}",
+            "Expected ${spyObj} to be called ${!expectedTimes} but was called ${!times}${!calls}",
         refuteMessage:
-            "Expected ${spyObj} to not be called exactly ${expectedTimes}${calls}",
+            "Expected ${spyObj} to not be called exactly ${!expectedTimes}${!calls}",
         expectation: "toHaveBeenCalled" + count,
         values: function(spyObj) {
             return {
@@ -205,7 +197,7 @@ referee.add("calledOn", {
         return spy.calledOn(thisObj);
     },
     assertMessage:
-        "Expected ${spyObj} to be called with ${expectedThis} as this but was called on ${actualThis}",
+        "Expected ${spyObj} to be called with ${expectedThis} as this but was called on ${!actualThis}",
     refuteMessage:
         "Expected ${spyObj} not to be called with ${expectedThis} as this",
     expectation: "toHaveBeenCalledOn",
@@ -218,25 +210,15 @@ referee.add("alwaysCalledOn", {
         return spy.alwaysCalledOn(thisObj);
     },
     assertMessage:
-        "Expected ${spyObj} to always be called with ${expectedThis} as this but was called on ${actualThis}",
+        "Expected ${spyObj} to always be called with ${expectedThis} as this but was called on ${!actualThis}",
     refuteMessage:
         "Expected ${spyObj} not to always be called with ${expectedThis} as this",
     expectation: "toHaveAlwaysBeenCalledOn",
     values: valuesWithThis
 });
 
-function formattedArgs(args, i) {
-    var index = i;
-    var l, result;
-
-    for (l = args.length, result = []; index < l; ++index) {
-        push.call(result, format(args[index]));
-    }
-    return result.join(", ");
-}
-
 function spyAndCalls(spyObj) {
-    var expected = formattedArgs(arguments, 1);
+    var expected = slice(arguments, 1);
     var actual = spyObj && spyObj.printf ? spyObj.printf("%C") : "";
     return {
         spyObj: spyObj,
@@ -251,9 +233,9 @@ referee.add("calledWith", {
         return spy.calledWith.apply(spy, slice(arguments, 1));
     },
     assertMessage:
-        "Expected ${spyObj} to be called with arguments ${expected}${actual}",
+        "Expected ${spyObj} to be called with arguments ${...expected}${!actual}",
     refuteMessage:
-        "Expected ${spyObj} not to be called with arguments ${expected}${actual}",
+        "Expected ${spyObj} not to be called with arguments ${...expected}${!actual}",
     expectation: "toHaveBeenCalledWith",
     values: spyAndCalls
 });
@@ -264,9 +246,9 @@ referee.add("alwaysCalledWith", {
         return spy.alwaysCalledWith.apply(spy, slice(arguments, 1));
     },
     assertMessage:
-        "Expected ${spyObj} to always be called with arguments ${expected}${actual}",
+        "Expected ${spyObj} to always be called with arguments ${...expected}${!actual}",
     refuteMessage:
-        "Expected ${spyObj} not to always be called with arguments ${expected}${actual}",
+        "Expected ${spyObj} not to always be called with arguments ${...expected}${!actual}",
     expectation: "toHaveAlwaysBeenCalledWith",
     values: spyAndCalls
 });
@@ -277,9 +259,9 @@ referee.add("calledOnceWith", {
         return spy.calledOnce && spy.calledWith.apply(spy, slice(arguments, 1));
     },
     assertMessage:
-        "Expected ${spyObj} to be called once with arguments ${expected}${actual}",
+        "Expected ${spyObj} to be called once with arguments ${...expected}${!actual}",
     refuteMessage:
-        "Expected ${spyObj} not to be called once with arguments ${expected}${actual}",
+        "Expected ${spyObj} not to be called once with arguments ${...expected}${!actual}",
     expectation: "toHaveBeenCalledOnceWith",
     values: spyAndCalls
 });
@@ -290,9 +272,9 @@ referee.add("calledWithExactly", {
         return spy.calledWithExactly.apply(spy, slice(arguments, 1));
     },
     assertMessage:
-        "Expected ${spyObj} to be called with exact arguments ${expected}${actual}",
+        "Expected ${spyObj} to be called with exact arguments ${...expected}${!actual}",
     refuteMessage:
-        "Expected ${spyObj} not to be called with exact arguments ${expected}${actual}",
+        "Expected ${spyObj} not to be called with exact arguments ${...expected}${!actual}",
     expectation: "toHaveBeenCalledWithExactly",
     values: spyAndCalls
 });
@@ -303,9 +285,9 @@ referee.add("alwaysCalledWithExactly", {
         return spy.alwaysCalledWithExactly.apply(spy, slice(arguments, 1));
     },
     assertMessage:
-        "Expected ${spyObj} to always be called with exact arguments ${expected}${actual}",
+        "Expected ${spyObj} to always be called with exact arguments ${...expected}${!actual}",
     refuteMessage:
-        "Expected ${spyObj} not to always be called with exact arguments ${expected}${actual}",
+        "Expected ${spyObj} not to always be called with exact arguments ${...expected}${!actual}",
     expectation: "toHaveAlwaysBeenCalledWithExactly",
     values: spyAndCalls
 });
@@ -316,9 +298,9 @@ referee.add("calledOnceWithExactly", {
         return spy.calledOnceWithExactly.apply(spy, slice(arguments, 1));
     },
     assertMessage:
-        "Expected ${spyObj} to be called once with exact arguments ${expected}${actual}",
+        "Expected ${spyObj} to be called once with exact arguments ${...expected}${!actual}",
     refuteMessage:
-        "Expected ${spyObj} not to be once called with exact arguments ${expected}${actual}",
+        "Expected ${spyObj} not to be called once with exact arguments ${...expected}${!actual}",
     expectation: "toHaveBeenCalledOnceWithExactly",
     values: spyAndCalls
 });
@@ -329,9 +311,9 @@ referee.add("calledWithMatch", {
         return spy.calledWithMatch.apply(spy, slice(arguments, 1));
     },
     assertMessage:
-        "Expected ${spyObj} to be called with matching arguments ${expected}${actual}",
+        "Expected ${spyObj} to be called with matching arguments ${...expected}${!actual}",
     refuteMessage:
-        "Expected ${spyObj} not to be called with matching arguments ${expected}${actual}",
+        "Expected ${spyObj} not to be called with matching arguments ${...expected}${!actual}",
     expectation: "toHaveBeenCalledWithMatch",
     values: spyAndCalls
 });
@@ -342,9 +324,9 @@ referee.add("calledOnceWithMatch", {
         return spy.calledOnceWithMatch.apply(spy, slice(arguments, 1));
     },
     assertMessage:
-        "Expected ${spyObj} to be called once with matching arguments ${expected}${actual}",
+        "Expected ${spyObj} to be called once with matching arguments ${...expected}${!actual}",
     refuteMessage:
-        "Expected ${spyObj} not to be called once with matching arguments ${expected}${actual}",
+        "Expected ${spyObj} not to be called once with matching arguments ${...expected}${!actual}",
     expectation: "toHaveBeenCalledOnceWithMatch",
     values: spyAndCalls
 });
@@ -355,9 +337,9 @@ referee.add("alwaysCalledWithMatch", {
         return spy.alwaysCalledWithMatch.apply(spy, slice(arguments, 1));
     },
     assertMessage:
-        "Expected ${spyObj} to always be called with matching arguments ${expected}${actual}",
+        "Expected ${spyObj} to always be called with matching arguments ${...expected}${!actual}",
     refuteMessage:
-        "Expected ${spyObj} not to always be called with matching arguments ${expected}${actual}",
+        "Expected ${spyObj} not to always be called with matching arguments ${...expected}${!actual}",
     expectation: "toHaveAlwaysBeenCalledWithMatch",
     values: spyAndCalls
 });
@@ -375,8 +357,8 @@ referee.add("threw", {
         verifyFakes.call(this, spy);
         return spy.threw(arguments[1]);
     },
-    assertMessage: "Expected ${spyObj} to throw an exception${actual}",
-    refuteMessage: "Expected ${spyObj} not to throw an exception${actual}",
+    assertMessage: "Expected ${spyObj} to throw an exception${!actual}",
+    refuteMessage: "Expected ${spyObj} not to throw an exception${!actual}",
     expectation: "toHaveThrown",
     values: spyAndException
 });
@@ -386,9 +368,9 @@ referee.add("alwaysThrew", {
         verifyFakes.call(this, spy);
         return spy.alwaysThrew(arguments[1]);
     },
-    assertMessage: "Expected ${spyObj} to always throw an exception${actual}",
+    assertMessage: "Expected ${spyObj} to always throw an exception${!actual}",
     refuteMessage:
-        "Expected ${spyObj} not to always throw an exception${actual}",
+        "Expected ${spyObj} not to always throw an exception${!actual}",
     expectation: "toAlwaysHaveThrown",
     values: spyAndException
 });

--- a/lib/referee-sinon.test.js
+++ b/lib/referee-sinon.test.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var inspect = require("util").inspect;
 var sinon = require("sinon");
 var referee = require("@sinonjs/referee");
 var formatio = require("@sinonjs/formatio");
@@ -95,21 +96,6 @@ describe("referee-sinon", function() {
     });
 
     describe("assertions", function() {
-        it("formats assert messages through formatio", function() {
-            sinon.stub(formatio, "ascii").returns("I'm the object");
-            var message;
-            var spy = sinon.spy();
-            spy({ id: 42 });
-
-            try {
-                assert.calledWith(spy, 3);
-            } catch (e) {
-                message = e.message;
-            }
-
-            assert.match(message, "I'm the object");
-        });
-
         describe("calledWith", function() {
             it("fails when not called with spy", requiresSpy("calledWith"));
 
@@ -129,8 +115,9 @@ describe("referee-sinon", function() {
                     throw new Error("Exception expected");
                 } catch (e) {
                     var message =
-                        "[assert.calledWith] Expected function " +
-                        "spy() {} to be called with arguments null, 2, 2" +
+                        "[assert.calledWith] Expected " +
+                        inspect(spy) +
+                        " to be called with arguments null, 2, 2" +
                         "\n    spy(null, 1, 2)";
                     assert.match(e.message, message);
                 }
@@ -152,8 +139,9 @@ describe("referee-sinon", function() {
                     throw new Error("Exception expected");
                 } catch (e) {
                     var message =
-                        "[assert.calledWith] Expected function " +
-                        "fake() {} to be called with arguments null, 2, 2" +
+                        "[assert.calledWith] Expected " +
+                        inspect(fake) +
+                        " to be called with arguments null, 2, 2" +
                         "\n    fake(null, 1, 2)";
                     assert.match(e.message, message);
                 }
@@ -183,7 +171,8 @@ describe("referee-sinon", function() {
                 } catch (e) {
                     var message =
                         "[assert.calledWithExactly] Expected " +
-                        "function spy() {} to be called with exact " +
+                        inspect(spy) +
+                        " to be called with exact " +
                         "arguments null, 2, 2\n    spy(null, 1, 2)";
                     assert.match(e.message, message);
                 }
@@ -223,7 +212,8 @@ describe("referee-sinon", function() {
                 } catch (e) {
                     var message =
                         "[assert.calledWithMatch] Expected " +
-                        "function spy() {} to be called with matching " +
+                        inspect(spy) +
+                        " to be called with matching " +
                         "arguments { check: 321 }\n    spy({ check: 123 })";
                     assert.match(e.message, message);
                 }
@@ -303,7 +293,8 @@ describe("referee-sinon", function() {
                 } catch (e) {
                     var message =
                         "[assert.calledOnceWithMatch] Expected " +
-                        "function spy() {} to be called once with matching arguments " +
+                        inspect(spy) +
+                        " to be called once with matching arguments " +
                         "null, 2, 2\n    spy(null, 1, 2)";
                     assert.match(e.message, message);
                 }
@@ -341,11 +332,12 @@ describe("referee-sinon", function() {
                 } catch (e) {
                     var message =
                         "[assert.alwaysCalledWithMatch] Expected " +
-                        "function spy() {} to always be called with " +
+                        inspect(spy) +
+                        " to always be called with " +
                         "matching arguments { check: 321 }";
-                    assert.match(e.message, message);
                     var lines = e.message.split("\n");
                     assert.equals(lines.length, 3);
+                    assert.equals(lines[0], message);
                     assert.match(lines[1], "    spy({ check: 123 })");
                     assert.match(lines[2], "    spy({ check: 321 })");
                 }
@@ -363,14 +355,17 @@ describe("referee-sinon", function() {
             });
 
             it("formats message nicely", function() {
+                var spy = sinon.spy();
+
                 try {
-                    assert.calledOnce(sinon.spy());
+                    assert.calledOnce(spy);
                     throw new Error("Exception expected");
                 } catch (e) {
                     var message =
-                        "[assert.calledOnce] Expected function " +
-                        "spy() {} to be called once but was called 0 times";
-                    assert.match(e.message, message);
+                        "[assert.calledOnce] Expected " +
+                        inspect(spy) +
+                        " to be called once but was called 0 times";
+                    assert.equals(e.message, message);
                 }
             });
         });
@@ -395,10 +390,11 @@ describe("referee-sinon", function() {
                     throw new Error("Exception expected");
                 } catch (e) {
                     var message =
-                        "[assert.calledTwice] Expected function " +
-                        "spy() {} to be called twice but was called once";
+                        "[assert.calledTwice] Expected " +
+                        inspect(spy) +
+                        " to be called twice but was called once";
                     assert.match(e.message, message);
-                    assert.match(e.message, "spy(null, Hey)");
+                    assert.match(e.message, "spy(null, 'Hey')");
                 }
             });
         });
@@ -425,11 +421,12 @@ describe("referee-sinon", function() {
                     throw new Error("Exception expected");
                 } catch (e) {
                     var message =
-                        "[assert.calledThrice] Expected function " +
-                        "spy() {} to be called thrice but was called twice";
+                        "[assert.calledThrice] Expected " +
+                        inspect(spy) +
+                        " to be called thrice but was called twice";
                     assert.match(e.message, message);
-                    assert.match(e.message, "spy(null, Hey)");
-                    assert.match(e.message, "spy(null, Ho)");
+                    assert.match(e.message, "spy(null, 'Hey')");
+                    assert.match(e.message, "spy(null, 'Ho')");
                 }
             });
         });
@@ -447,12 +444,16 @@ describe("referee-sinon", function() {
             });
 
             it("formats message nicely", function() {
+                var spy = sinon.spy();
+
                 try {
-                    assert.callCount(sinon.spy(), 1);
+                    assert.callCount(spy, 1);
                     throw new Error("Exception expected");
                 } catch (e) {
                     var message =
-                        "[assert.callCount] Expected function spy() {} to be called exactly 1 times, but was called 0 times";
+                        "[assert.callCount] Expected " +
+                        inspect(spy) +
+                        " to be called exactly 1 times, but was called 0 times";
                     assert.match(e.message, message);
                 }
             });
@@ -469,13 +470,16 @@ describe("referee-sinon", function() {
             });
 
             it("formats message", function() {
+                var spy = sinon.spy();
+
                 try {
-                    assert.called(sinon.spy());
+                    assert.called(spy);
                     throw new Error("Exception expected");
                 } catch (e) {
                     var message =
-                        "[assert.called] Expected function spy() " +
-                        "{} to be called at least once but was never " +
+                        "[assert.called] Expected " +
+                        inspect(spy) +
+                        " to be called at least once but was never " +
                         "called";
                     assert.equals(e.message, message);
                 }
@@ -495,15 +499,17 @@ describe("referee-sinon", function() {
             });
 
             it("formats message", function() {
-                try {
-                    var spy = sinon.spy();
-                    spy();
+                var spy = sinon.spy();
+                spy();
 
+                try {
                     assert.calledWithNew(spy);
                     throw new Error("Exception expected");
                 } catch (e) {
                     var message =
-                        "[assert.calledWithNew] Expected function spy() {} to be called with 'new' at least once but was never called with 'new'";
+                        "[assert.calledWithNew] Expected " +
+                        inspect(spy) +
+                        " to be called with 'new' at least once but was never called with 'new'";
                     assert.equals(e.message, message);
                 }
             });
@@ -538,16 +544,18 @@ describe("referee-sinon", function() {
             });
 
             it("formats message", function() {
-                try {
-                    var spy = sinon.spy();
-                    spy();
-                    spy();
+                var spy = sinon.spy();
+                spy();
+                spy();
 
+                try {
                     assert.alwaysCalledWithNew(spy);
                     throw new Error("Exception expected");
                 } catch (e) {
                     var message =
-                        "[assert.alwaysCalledWithNew] Expected function spy() {} to always be called with 'new'";
+                        "[assert.alwaysCalledWithNew] Expected " +
+                        inspect(spy) +
+                        " to always be called with 'new'";
                     assert.equals(e.message, message);
                 }
             });
@@ -610,8 +618,9 @@ describe("referee-sinon", function() {
                     throw new Error("Exception expected");
                 } catch (e) {
                     var message =
-                        "[assert.calledOn] Expected function spy() " +
-                        "{} to be called with { id: 12 } as this but was " +
+                        "[assert.calledOn] Expected " +
+                        inspect(spy) +
+                        " to be called with { id: 12 } as this but was " +
                         "called on { id: 42 }";
                     assert.equals(e.message, message);
                 }
@@ -650,8 +659,9 @@ describe("referee-sinon", function() {
                     throw new Error("Exception expected");
                 } catch (e) {
                     var message =
-                        "[assert.alwaysCalledOn] Expected function " +
-                        "spy() {} to always be called with { id: 12 } as " +
+                        "[assert.alwaysCalledOn] Expected " +
+                        inspect(spy) +
+                        " to always be called with { id: 12 } as " +
                         "this but was called on { id: 42 }";
                     assert.equals(e.message, message);
                 }
@@ -682,7 +692,8 @@ describe("referee-sinon", function() {
                 } catch (e) {
                     var message =
                         "[assert.alwaysCalledWith] Expected " +
-                        "function spy() {} to always be called with " +
+                        inspect(spy) +
+                        " to always be called with " +
                         "arguments 12\n    spy(42)";
                     assert.match(e.message, message);
                 }
@@ -712,7 +723,8 @@ describe("referee-sinon", function() {
                 } catch (e) {
                     var message =
                         "[assert.alwaysCalledWithExactly] Expected " +
-                        "function spy() {} to always be called with " +
+                        inspect(spy) +
+                        " to always be called with " +
                         "exact arguments null, 2, 2\n    spy(null, 1, 2)";
                     assert.match(e.message, message);
                 }
@@ -755,7 +767,8 @@ describe("referee-sinon", function() {
                 } catch (e) {
                     var message =
                         "[assert.calledOnceWithExactly] Expected " +
-                        "function spy() {} to be called once with exact arguments " +
+                        inspect(spy) +
+                        " to be called once with exact arguments " +
                         "null, 2, 2\n    spy(null, 1, 2)";
                     assert.match(e.message, message);
                 }
@@ -782,9 +795,10 @@ describe("referee-sinon", function() {
                     throw new Error("Exception expected");
                 } catch (e) {
                     var message =
-                        "[assert.threw] Expected function spy() " +
-                        "{} to throw an exception";
-                    assert.match(e.message, message);
+                        "[assert.threw] Expected " +
+                        inspect(spy) +
+                        " to throw an exception";
+                    assert.equals(e.message, message);
                 }
             });
 
@@ -818,9 +832,10 @@ describe("referee-sinon", function() {
                     throw new Error("Exception expected");
                 } catch (e) {
                     var message =
-                        "[assert.alwaysThrew] Expected function " +
-                        "spy() {} to always throw an exception";
-                    assert.match(e.message, message);
+                        "[assert.alwaysThrew] Expected " +
+                        inspect(spy) +
+                        " to always throw an exception";
+                    assert.equals(e.message, message);
                 }
             });
         });
@@ -862,8 +877,9 @@ describe("referee-sinon", function() {
                     throw new Error("Exception expected");
                 } catch (e) {
                     var message =
-                        "[assert.calledOnceWith] Expected function " +
-                        "spy() {} to be called once with arguments 12\n" +
+                        "[assert.calledOnceWith] Expected " +
+                        inspect(spy) +
+                        " to be called once with arguments 12\n" +
                         "    spy(42)";
                     assert.match(e.message, message);
                 }

--- a/lib/referee-sinon.test.js
+++ b/lib/referee-sinon.test.js
@@ -146,6 +146,23 @@ describe("referee-sinon", function() {
                     assert.match(e.message, message);
                 }
             });
+
+            it("formats error argument", function() {
+                var fake = sinon.fake();
+                fake(new Error());
+
+                try {
+                    assert.calledWith(fake, null);
+                    throw new Error("Exception expected");
+                } catch (e) {
+                    var message =
+                        "[assert.calledWith] Expected " +
+                        inspect(fake) +
+                        " to be called with arguments null" +
+                        "\n    fake(Error)";
+                    assert.match(e.message, message);
+                }
+            });
         });
 
         describe("calledWithExactly", function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -292,12 +292,11 @@
       }
     },
     "@sinonjs/referee": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-6.0.1.tgz",
-      "integrity": "sha512-KkLLCJGBRBt62iAqvzoK87eIWXIZMW0E/DoOQcjFiUoDT79YAfDx1GcbQYpBt83s8Uugq9tRoYpP0FSU5TsGlw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-6.1.0.tgz",
+      "integrity": "sha512-AzX3QFJYF12qZATQifQw/VOlm4L+dM23IgQr/KjRhokj7caAwKuVt7xQLzbVAv7+nh8v+nc2sRJogfN7bhHpOQ==",
       "requires": {
         "@sinonjs/commons": "^1.4.0",
-        "@sinonjs/formatio": "^5.0.1",
         "@sinonjs/samsam": "^5.0.2",
         "array-from": "2.1.1",
         "lodash.includes": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@sinonjs/commons": "^1.8.1",
     "@sinonjs/formatio": "^5.0.1",
-    "@sinonjs/referee": "^6.0.1",
+    "@sinonjs/referee": "^6.1.0",
     "sinon": "^9.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   },
   "dependencies": {
     "@sinonjs/commons": "^1.8.1",
-    "@sinonjs/formatio": "^5.0.1",
     "@sinonjs/referee": "^6.1.0",
     "sinon": "^9.1.0"
   }


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

Following up on https://github.com/sinonjs/referee/pull/183, this removes the dependency on `@sinonjs/formatio` and uses `util.inspect` for object stringification.

We want to get rid of `@sinonjs/formatio` in all Sinon projects and use `util.inspect` instead.

Since we released the mentioned PR as a patch which unfortunately breaks this module, we shouldn't release this change as a major. I would do a minor release.

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. `npm test`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).

Closes #97