### PR TITLE
Run tests in node 14, instead of 13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,9 +69,9 @@ jobs:
           name: Upload coverage report
           command: bash <(curl -s https://codecov.io/bash) -F unit -s coverage/lcov.info
 
-  node-13:
+  node-14:
     docker:
-      - image: circleci/node:13
+      - image: circleci/node:14
     steps:
       - *attach-step
       - run:
@@ -103,7 +103,7 @@ workflows:
       - node-12:
           requires:
             - install-dependencies
-      - node-13:
+      - node-14:
           requires:
             - install-dependencies
       - saucelabs:
@@ -111,7 +111,7 @@ workflows:
             - lint
             - node-10
             - node-12
-            - node-13
+            - node-14
           filters:
             branches:
               only: master


### PR DESCRIPTION
This PR updates the CircleCI configuration to run tests in Node 14, replacing Node 13.
