### PR TITLE
Improve messages from calledOnceWith

### DIFF
--- a/lib/args-as-string.js
+++ b/lib/args-as-string.js
@@ -1,0 +1,15 @@
+"use strict";
+
+/**
+ * Returns a comma separated string
+ *
+ * @param  {arguments} args Arguments object from a function invocation
+ * @returns {string}
+ */
+function argsAsString(args) {
+  return Array.from(args)
+    .map((v) => String(v))
+    .join(", ");
+}
+
+module.exports = argsAsString;

--- a/lib/referee-sinon.js
+++ b/lib/referee-sinon.js
@@ -8,6 +8,8 @@ var orderByFirstCall = require("@sinonjs/commons").orderByFirstCall;
 var referee = require("@sinonjs/referee");
 var sinon = require("sinon");
 
+var argsAsString = require("./args-as-string");
+
 var timesInWords = [null, "once", "twice", "thrice"];
 
 function callCount(fake) {
@@ -251,18 +253,41 @@ referee.add("alwaysCalledWith", {
   values: spyAndCalls,
 });
 
-referee.add("calledOnceWith", {
-  assert: function (spy) {
+function createCalledOnceWith(ref) {
+  let assertMessage;
+
+  function assertFn(spy) {
     verifyFakes.call(this, spy);
-    return spy.calledOnce && spy.calledWith.apply(spy, slice(arguments, 1));
-  },
-  assertMessage:
-    "Expected ${spyObj} to be called once with arguments ${...expected}${!actual}",
-  refuteMessage:
-    "Expected ${spyObj} not to be called once with arguments ${...expected}${!actual}",
-  expectation: "toHaveBeenCalledOnceWith",
-  values: spyAndCalls,
-});
+
+    if (!spy.calledOnce) {
+      assertMessage = `Expected \${spyObj} to be called once, but was called ${spy.callCount} times`;
+      return false;
+    }
+
+    if (!spy.calledWith.apply(spy, slice(arguments, 1))) {
+      assertMessage = `Expected \${spyObj} to be called with arguments \${...expected}, but was called with ${argsAsString(
+        spy.args[0]
+      )}`;
+      return false;
+    }
+
+    return true;
+  }
+
+  function assertMessageFn() {
+    return assertMessage;
+  }
+
+  ref.add("calledOnceWith", {
+    assert: assertFn,
+    assertMessage: assertMessageFn,
+    refuteMessage:
+      "Expected ${spyObj} not to be called once with ${...expected}",
+    expectation: "toHaveBeenCalledOnceWith",
+    values: spyAndCalls,
+  });
+}
+createCalledOnceWith(referee);
 
 referee.add("calledWithExactly", {
   assert: function (spy) {
@@ -290,18 +315,41 @@ referee.add("alwaysCalledWithExactly", {
   values: spyAndCalls,
 });
 
-referee.add("calledOnceWithExactly", {
-  assert: function (spy) {
+function createCalledOnceWithExactly(ref) {
+  let assertMessage;
+
+  function assertFn(spy) {
     verifyFakes.call(this, spy);
-    return spy.calledOnceWithExactly.apply(spy, slice(arguments, 1));
-  },
-  assertMessage:
-    "Expected ${spyObj} to be called once with exact arguments ${...expected}${!actual}",
-  refuteMessage:
-    "Expected ${spyObj} not to be called once with exact arguments ${...expected}${!actual}",
-  expectation: "toHaveBeenCalledOnceWithExactly",
-  values: spyAndCalls,
-});
+
+    if (!spy.calledOnce) {
+      assertMessage = `Expected \${spyObj} to be called once, but was called ${spy.callCount} times`;
+      return false;
+    }
+
+    if (!spy.calledWithExactly.apply(spy, slice(arguments, 1))) {
+      assertMessage = `Expected \${spyObj} to be called once with exact arguments \${...expected}, but was called with ${argsAsString(
+        spy.args[0]
+      )}`;
+      return false;
+    }
+
+    return true;
+  }
+
+  function assertMessageFn() {
+    return assertMessage;
+  }
+
+  ref.add("calledOnceWithExactly", {
+    assert: assertFn,
+    assertMessage: assertMessageFn,
+    refuteMessage:
+      "Expected ${spyObj} not to be called once with exact arguments ${...expected}${!actual}",
+    expectation: "toHaveBeenCalledOnceWithExactly",
+    values: spyAndCalls,
+  });
+}
+createCalledOnceWithExactly(referee);
 
 referee.add("calledWithMatch", {
   assert: function (spy) {
@@ -316,18 +364,41 @@ referee.add("calledWithMatch", {
   values: spyAndCalls,
 });
 
-referee.add("calledOnceWithMatch", {
-  assert: function (spy) {
+function createCalledOnceWithMatch(ref) {
+  let assertMessage;
+
+  function assertFn(spy) {
     verifyFakes.call(this, spy);
-    return spy.calledOnceWithMatch.apply(spy, slice(arguments, 1));
-  },
-  assertMessage:
-    "Expected ${spyObj} to be called once with matching arguments ${...expected}${!actual}",
-  refuteMessage:
-    "Expected ${spyObj} not to be called once with matching arguments ${...expected}${!actual}",
-  expectation: "toHaveBeenCalledOnceWithMatch",
-  values: spyAndCalls,
-});
+
+    if (!spy.calledOnce) {
+      assertMessage = `Expected \${spyObj} to be called once, but was called ${spy.callCount} times`;
+      return false;
+    }
+
+    if (!spy.calledWithMatch.apply(spy, slice(arguments, 1))) {
+      assertMessage = `Expected \${spyObj} to be called once with matching arguments \${...expected}, but was called with ${argsAsString(
+        spy.args[0]
+      )}`;
+      return false;
+    }
+
+    return true;
+  }
+
+  function assertMessageFn() {
+    return assertMessage;
+  }
+
+  ref.add("calledOnceWithMatch", {
+    assert: assertFn,
+    assertMessage: assertMessageFn,
+    refuteMessage:
+      "Expected ${spyObj} not to be called once with matching arguments ${...expected}${!actual}",
+    expectation: "toHaveBeenCalledOnceWithMatch",
+    values: spyAndCalls,
+  });
+}
+createCalledOnceWithMatch(referee);
 
 referee.add("alwaysCalledWithMatch", {
   assert: function (spy) {

--- a/lib/referee-sinon.test.js
+++ b/lib/referee-sinon.test.js
@@ -288,12 +288,21 @@ describe("referee-sinon", function () {
           assert.calledOnceWithMatch(spy, null, 2, 2);
           throw new Error("Exception expected");
         } catch (e) {
-          var message =
-            `[assert.calledOnceWithMatch] Expected ${inspect(
-              spy
-            )} to be called once with matching arguments ` +
-            `null, 2, 2\n    spy(null, 1, 2)`;
-          assert.match(e.message, message);
+          var message1 = `[assert.calledOnceWithMatch] Expected ${inspect(
+            spy
+          )} to be called once with matching arguments null, 2, 2, but was called with null, 1, 2`;
+          assert.match(e.message, message1);
+        }
+
+        spy(null, 1, 2);
+        try {
+          assert.calledOnceWithMatch(spy, null, 2, 2);
+          throw new Error("Exception expected");
+        } catch (e) {
+          var message2 = `Expected ${inspect(
+            spy
+          )} to be called once, but was called 2 times`;
+          assert.match(e.message, message2);
         }
       });
     });
@@ -708,6 +717,13 @@ describe("referee-sinon", function () {
     });
 
     describe("calledOnceWithExactly", function () {
+      it("passes when called once with expected arguments", function () {
+        var spy = sinon.spy();
+        spy(42);
+
+        assert.calledOnceWithExactly(spy, 42);
+      });
+
       it(
         "fails when not called with spy",
         requiresSpy("calledOnceWithExactly")
@@ -738,12 +754,22 @@ describe("referee-sinon", function () {
           assert.calledOnceWithExactly(spy, null, 2, 2);
           throw new Error("Exception expected");
         } catch (e) {
-          var message =
-            `[assert.calledOnceWithExactly] Expected ${inspect(
-              spy
-            )} to be called once with exact arguments ` +
-            `null, 2, 2\n    spy(null, 1, 2)`;
+          var message = `[assert.calledOnceWithExactly] Expected ${inspect(
+            spy
+          )} to be called once with exact arguments null, 2, 2, but was called with null, 1, 2`;
           assert.match(e.message, message);
+        }
+
+        spy(null, 1, 2);
+
+        try {
+          assert.calledOnceWithExactly(spy, null, 2, 2);
+          throw new Error("Exception expected");
+        } catch (e) {
+          var message2 = `[assert.calledOnceWithExactly] Expected ${inspect(
+            spy
+          )} to be called once, but was called 2 times`;
+          assert.match(e.message, message2);
         }
       });
     });
@@ -847,10 +873,21 @@ describe("referee-sinon", function () {
           assert.calledOnceWith(spy, 12);
           throw new Error("Exception expected");
         } catch (e) {
-          var message = `[assert.calledOnceWith] Expected ${inspect(
+          var message1 = `[assert.calledOnceWith] Expected ${inspect(
             spy
-          )} to be called once with arguments 12\n    spy(42)`;
-          assert.match(e.message, message);
+          )} to be called with arguments 12, but was called with 42`;
+          assert.match(e.message, message1);
+        }
+
+        spy(42);
+        try {
+          assert.calledOnceWith(spy, 42);
+          throw new Error("Exception expected");
+        } catch (e) {
+          var message2 = `[assert.calledOnceWith] Expected ${inspect(
+            spy
+          )} to be called once, but was called 2 times`;
+          assert.match(e.message, message2);
         }
       });
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/referee": "^9.0.0",
+        "@sinonjs/referee": "^9.1.0",
         "sinon": "^11.1.1",
         "util": "^0.12.3"
       },
@@ -381,9 +381,9 @@
       }
     },
     "node_modules/@sinonjs/referee": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-9.0.0.tgz",
-      "integrity": "sha512-3tURAFq7nmQ9nSkZ5vxE9gXiixVl6Te8sty81sch4+gI8vIInmdXb5eyfrNphKAHmJEo6a1s9uo5MrRwRe0Ozw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-9.1.0.tgz",
+      "integrity": "sha512-x+w0XWhIKy5mn0nr6pCO++5ewAbCgFI5wROksxKC8iyQ0KF47yt+tSjBc4JKuqpMGxcWWgrsoHl+fRVBCiVJmQ==",
       "dependencies": {
         "@sinonjs/commons": "^1.8.3",
         "@sinonjs/samsam": "^6.0.2",
@@ -8598,9 +8598,9 @@
       }
     },
     "@sinonjs/referee": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-9.0.0.tgz",
-      "integrity": "sha512-3tURAFq7nmQ9nSkZ5vxE9gXiixVl6Te8sty81sch4+gI8vIInmdXb5eyfrNphKAHmJEo6a1s9uo5MrRwRe0Ozw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-9.1.0.tgz",
+      "integrity": "sha512-x+w0XWhIKy5mn0nr6pCO++5ewAbCgFI5wROksxKC8iyQ0KF47yt+tSjBc4JKuqpMGxcWWgrsoHl+fRVBCiVJmQ==",
       "requires": {
         "@sinonjs/commons": "^1.8.3",
         "@sinonjs/samsam": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@sinonjs/commons": "^1.8.3",
-    "@sinonjs/referee": "^9.0.0",
+    "@sinonjs/referee": "^9.1.0",
     "sinon": "^11.1.1",
     "util": "^0.12.3"
   }


### PR DESCRIPTION
This PR improves the messages from `calledOnceWith`, `calledOnceWithExactly` and `calledOnceWithMatch`.

The old message

```
[assert.calledOnceWith] Expected [Function (anonymous)] to be called once with arguments 1
```

Does not reveal whether the spy was called multiple times or with unexpected arguments

After this changset, there are two messages:

```
[assert.calledOnceWith] Expected [Function (anonymous)] to be called once, but was called 2 times
[assert.calledOnceWith] Expected [Function (anonymous)] to be called with arguments 2, but was called with 1
```

These messages clearly indicate which of the two combined expectations were unmet

#### Purpose (TL;DR) - mandatory

<!--
> give a concise (one or two short sentences) description of what what problem is being solved by this PR
>
> Example: Fix issue #123456 by re-structuring the colour selection conditional in method `paintBlue`
-->

<!--
#### Background (Problem in detail)  - optional
-->
<!--
> When relevant, give a more thorough description of what the problem the PR is trying to solve. Examples of good topics for this section are:
> * Link to an existing GitHub issue describing the problem
> * Describing the problem in greater detail than the TL;DR section above
> * How you discovered the issue, if it's not already described as an issue on GitHub
> * Discussion of different approaches to solving this problem and why you chose your proposed solution
-->

<!--
#### Solution  - optional
-->
<!--
> When contributing code (and not just fixing typos, documentation and configuration), please describe why/how your solution works. This helps reviewers spot any mistakes in the implementation.
>
> Example:
> "This solution works by adding a `paintBlue()` method"
> Then your reviewer might spot a mistake in the implementation, if `paintBlue()` uses the colour red.
-->

#### How to verify - mandatory

0. Check out https://github.com/sinonjs/referee/pull/234
1. `npm link`
1. Check out this branch
2. `npm install`
3. `npm link @sinonjs/referee`
4. Run the tests
5. Observe that the updated tests are passing

~~There is some unrelated test failure when linking, that @hexeberlin and I have not been able to figure out yet. It also happens when using `master` branches from both repositories.~~ As suspected, when using the `@sinonjs/referee` package from `npm` registry, things just work™️.

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
