### PR TITLE
Support module import and upgrade Sinon and Referee

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-$(npm bin)/lint-staged
+node_modules/.bin/lint-staged

--- a/lib/referee-sinon.js
+++ b/lib/referee-sinon.js
@@ -444,6 +444,8 @@ referee.add("alwaysThrew", {
   values: spyAndException,
 });
 
-referee.sinon = sinon;
-
 module.exports = referee;
+module.exports.sinon = sinon;
+module.exports.assert = referee.assert;
+module.exports.refute = referee.refute;
+module.exports.match = referee.match;

--- a/lib/referee-sinon.js
+++ b/lib/referee-sinon.js
@@ -1,7 +1,6 @@
 /* eslint-disable jsdoc/require-jsdoc */
 "use strict";
 
-var inspect = require("util").inspect;
 var slice = require("@sinonjs/commons").prototypes.array.slice;
 var calledInOrder = require("@sinonjs/commons").calledInOrder;
 var orderByFirstCall = require("@sinonjs/commons").orderByFirstCall;
@@ -41,15 +40,6 @@ sinon.expectation.pass = function (assertion) {
 sinon.expectation.fail = function (message) {
   referee.fail(message);
 };
-
-function format(object) {
-  if (object instanceof Error) {
-    return object.name;
-  }
-  return inspect(object);
-}
-
-sinon.setFormatter(format);
 
 function verifyFakes() {
   var method, isNot, i, l;

--- a/lib/referee-sinon.test.js
+++ b/lib/referee-sinon.test.js
@@ -143,7 +143,8 @@ describe("referee-sinon", function () {
 
       it("formats error argument", function () {
         var fake = sinon.fake();
-        fake(new Error());
+        var error = new Error();
+        fake(error);
 
         try {
           assert.calledWith(fake, null);
@@ -151,7 +152,7 @@ describe("referee-sinon", function () {
         } catch (e) {
           var message = `[assert.calledWith] Expected ${inspect(
             fake
-          )} to be called with arguments null\n    fake(Error)`;
+          )} to be called with arguments null\n    fake(${inspect(error)})`;
           assert.match(e.message, message);
         }
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/referee": "^9.1.0",
-        "sinon": "^11.1.1",
+        "@sinonjs/referee": "^10.0.0",
+        "sinon": "^15.0.1",
         "util": "^0.12.3"
       },
       "devDependencies": {
@@ -693,63 +693,39 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
-      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
       "dependencies": {
-        "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.5.tgz",
-      "integrity": "sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==",
-      "dependencies": {
-        "type-detect": "4.0.8"
+        "@sinonjs/commons": "^2.0.0"
       }
     },
     "node_modules/@sinonjs/referee": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-9.1.0.tgz",
-      "integrity": "sha512-x+w0XWhIKy5mn0nr6pCO++5ewAbCgFI5wROksxKC8iyQ0KF47yt+tSjBc4JKuqpMGxcWWgrsoHl+fRVBCiVJmQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-10.0.0.tgz",
+      "integrity": "sha512-EZsJAAeBpMa4unEXGxdGiceg0LOtwMzIQIAuQTzVwnLPr3cohQNjLIi25lwj3a0ZjatYGvCmcUWC6o27eVRfCg==",
       "dependencies": {
-        "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/samsam": "^6.0.2",
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/samsam": "^7.0.1",
         "event-emitter": "^0.3.5",
         "lodash.isarguments": "^3.1.0",
-        "util": "^0.12.3"
-      }
-    },
-    "node_modules/@sinonjs/referee/node_modules/@sinonjs/commons": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.5.tgz",
-      "integrity": "sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==",
-      "dependencies": {
-        "type-detect": "4.0.8"
+        "util": "^0.12.5"
       }
     },
     "node_modules/@sinonjs/samsam": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.0.2.tgz",
-      "integrity": "sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-7.0.1.tgz",
+      "integrity": "sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==",
       "dependencies": {
-        "@sinonjs/commons": "^1.6.0",
+        "@sinonjs/commons": "^2.0.0",
         "lodash.get": "^4.4.2",
         "type-detect": "^4.0.8"
       }
     },
-    "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.5.tgz",
-      "integrity": "sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==",
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
     "node_modules/@sinonjs/text-encoding": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
-      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ=="
     },
     "node_modules/@studio/changes": {
       "version": "2.2.0",
@@ -5252,23 +5228,15 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "node_modules/nise": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
-      "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
+      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
       "dependencies": {
-        "@sinonjs/commons": "^1.7.0",
-        "@sinonjs/fake-timers": "^7.0.4",
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
-      }
-    },
-    "node_modules/nise/node_modules/@sinonjs/commons": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.5.tgz",
-      "integrity": "sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==",
-      "dependencies": {
-        "type-detect": "4.0.8"
       }
     },
     "node_modules/node-fetch": {
@@ -6271,7 +6239,8 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -6450,28 +6419,20 @@
       ]
     },
     "node_modules/sinon": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.1.tgz",
-      "integrity": "sha512-ZSSmlkSyhUWbkF01Z9tEbxZLF/5tRC9eojCdFh33gtQaP7ITQVaMWQHGuFM7Cuf/KEfihuh1tTl3/ABju3AQMg==",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.1.tgz",
+      "integrity": "sha512-PZXKc08f/wcA/BMRGBze2Wmw50CWPiAH3E21EOi4B49vJ616vW4DQh4fQrqsYox2aNR/N3kCqLuB0PwwOucQrg==",
       "dependencies": {
-        "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^7.1.0",
-        "@sinonjs/samsam": "^6.0.2",
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "10.0.2",
+        "@sinonjs/samsam": "^7.0.1",
         "diff": "^5.0.0",
-        "nise": "^5.1.0",
+        "nise": "^5.1.2",
         "supports-color": "^7.2.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/sinon"
-      }
-    },
-    "node_modules/sinon/node_modules/@sinonjs/commons": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.5.tgz",
-      "integrity": "sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==",
-      "dependencies": {
-        "type-detect": "4.0.8"
       }
     },
     "node_modules/slash": {
@@ -7120,15 +7081,14 @@
       "dev": true
     },
     "node_modules/util": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
-      "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
         "is-generator-function": "^1.0.7",
         "is-typed-array": "^1.1.3",
-        "safe-buffer": "^5.1.2",
         "which-typed-array": "^1.1.2"
       }
     },
@@ -8127,69 +8087,39 @@
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
-      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
       "requires": {
-        "@sinonjs/commons": "^1.7.0"
-      },
-      "dependencies": {
-        "@sinonjs/commons": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.5.tgz",
-          "integrity": "sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==",
-          "requires": {
-            "type-detect": "4.0.8"
-          }
-        }
+        "@sinonjs/commons": "^2.0.0"
       }
     },
     "@sinonjs/referee": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-9.1.0.tgz",
-      "integrity": "sha512-x+w0XWhIKy5mn0nr6pCO++5ewAbCgFI5wROksxKC8iyQ0KF47yt+tSjBc4JKuqpMGxcWWgrsoHl+fRVBCiVJmQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/referee/-/referee-10.0.0.tgz",
+      "integrity": "sha512-EZsJAAeBpMa4unEXGxdGiceg0LOtwMzIQIAuQTzVwnLPr3cohQNjLIi25lwj3a0ZjatYGvCmcUWC6o27eVRfCg==",
       "requires": {
-        "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/samsam": "^6.0.2",
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/samsam": "^7.0.1",
         "event-emitter": "^0.3.5",
         "lodash.isarguments": "^3.1.0",
-        "util": "^0.12.3"
-      },
-      "dependencies": {
-        "@sinonjs/commons": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.5.tgz",
-          "integrity": "sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==",
-          "requires": {
-            "type-detect": "4.0.8"
-          }
-        }
+        "util": "^0.12.5"
       }
     },
     "@sinonjs/samsam": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.0.2.tgz",
-      "integrity": "sha512-jxPRPp9n93ci7b8hMfJOFDPRLFYadN6FSpeROFTR4UNF4i5b+EK6m4QXPO46BDhFgRy1JuS87zAnFOzCUwMJcQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-7.0.1.tgz",
+      "integrity": "sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==",
       "requires": {
-        "@sinonjs/commons": "^1.6.0",
+        "@sinonjs/commons": "^2.0.0",
         "lodash.get": "^4.4.2",
         "type-detect": "^4.0.8"
-      },
-      "dependencies": {
-        "@sinonjs/commons": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.5.tgz",
-          "integrity": "sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==",
-          "requires": {
-            "type-detect": "4.0.8"
-          }
-        }
       }
     },
     "@sinonjs/text-encoding": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
-      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ=="
     },
     "@studio/changes": {
       "version": "2.2.0",
@@ -11654,25 +11584,15 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nise": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.0.tgz",
-      "integrity": "sha512-W5WlHu+wvo3PaKLsJJkgPup2LrsXCcm7AWwyNZkUnn5rwPkuPBi3Iwk5SQtN0mv+K65k7nKKjwNQ30wg3wLAQQ==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
+      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
       "requires": {
-        "@sinonjs/commons": "^1.7.0",
-        "@sinonjs/fake-timers": "^7.0.4",
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
-      },
-      "dependencies": {
-        "@sinonjs/commons": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.5.tgz",
-          "integrity": "sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==",
-          "requires": {
-            "type-detect": "4.0.8"
-          }
-        }
       }
     },
     "node-fetch": {
@@ -12455,7 +12375,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -12595,26 +12516,16 @@
       "dev": true
     },
     "sinon": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.1.tgz",
-      "integrity": "sha512-ZSSmlkSyhUWbkF01Z9tEbxZLF/5tRC9eojCdFh33gtQaP7ITQVaMWQHGuFM7Cuf/KEfihuh1tTl3/ABju3AQMg==",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.1.tgz",
+      "integrity": "sha512-PZXKc08f/wcA/BMRGBze2Wmw50CWPiAH3E21EOi4B49vJ616vW4DQh4fQrqsYox2aNR/N3kCqLuB0PwwOucQrg==",
       "requires": {
-        "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^7.1.0",
-        "@sinonjs/samsam": "^6.0.2",
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "10.0.2",
+        "@sinonjs/samsam": "^7.0.1",
         "diff": "^5.0.0",
-        "nise": "^5.1.0",
+        "nise": "^5.1.2",
         "supports-color": "^7.2.0"
-      },
-      "dependencies": {
-        "@sinonjs/commons": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.5.tgz",
-          "integrity": "sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==",
-          "requires": {
-            "type-detect": "4.0.8"
-          }
-        }
       }
     },
     "slash": {
@@ -13157,15 +13068,14 @@
       }
     },
     "util": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
-      "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
       "requires": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
         "is-generator-function": "^1.0.7",
         "is-typed-array": "^1.1.3",
-        "safe-buffer": "^5.1.2",
         "which-typed-array": "^1.1.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
   },
   "dependencies": {
     "@sinonjs/commons": "^2.0.0",
-    "@sinonjs/referee": "^9.1.0",
-    "sinon": "^11.1.1",
+    "@sinonjs/referee": "^10.0.0",
+    "sinon": "^15.0.1",
     "util": "^0.12.3"
   }
 }


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory

- Allow this package to be consume with `import '@sinonjs/referee-sinon'`
- Upgrade sinon to latest (v15)
- Upgrade referee to latest (v10)
- Make sure there is only one version of `@sinonjs/commons` and `@sinonjs/samsam` in the dependency tree.

#### Background (Problem in detail)  - optional

Without explicitly exporting the `assert`, `refute`, `match` and `sinon` instances, consuming this package with `import` fails:

```
import { sinon } from '@sinonjs/referee-sinon';
         ^^^^^
SyntaxError: Named export 'sinon' not found. The requested module '@sinonjs/referee-sinon' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from '@sinonjs/referee-sinon';
const { sinon } = pkg;

    at ModuleJob._instantiate (node:internal/modules/esm/module_job:124:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:190:5)
```

#### Solution  - optional

Simply exporting the properties explicitly is good enough to get this working.

#### How to verify - mandatory

1. Check out this branch
2. `npm install`
3. `npm pack`
4. `npm install ../../sinon/referee-sinon/sinonjs-referee-sinon-10.1.1.tgz --no-save` from another module
5. Try to load the library with `import { sinon } from '@sinonjs/referee-sinon'`

#### Checklist for author

- [x] `npm run lint` passes
- [x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
